### PR TITLE
 Add tests for struct field order importing. Fixes #171.

### DIFF
--- a/test/ASTMerge/category/test.m
+++ b/test/ASTMerge/category/test.m
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/category1.m
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/category2.m
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: category2.m:18:1: error: instance method 'method2' has incompatible result types in different translation units ('float' vs. 'int')
 // CHECK: category1.m:16:1: note: instance method 'method2' also declared here

--- a/test/ASTMerge/class-template-partial-spec/test.cpp
+++ b/test/ASTMerge/class-template-partial-spec/test.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.1.ast %S/Inputs/class-template-partial-spec1.cpp
 // RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.2.ast %S/Inputs/class-template-partial-spec2.cpp
-// RUN: not %clang_cc1 -std=c++1z -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -std=c++1z -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 static_assert(sizeof(**SingleSource.member) == sizeof(**SingleDest.member));
 static_assert(sizeof(SecondDoubleSource.member) == sizeof(SecondDoubleDest.member));
@@ -15,7 +15,7 @@ static_assert(sizeof(One::Child1<double, One::Two::Three::Parent<double>>::membe
 // CHECK: class-template-partial-spec2.cpp:24:29: error: external variable 'X4' declared with incompatible types in different translation units ('TwoOptionTemplate<int, int>' vs. 'TwoOptionTemplate<float, float>')
 // CHECK: class-template-partial-spec1.cpp:24:33: note: declared here with type 'TwoOptionTemplate<float, float>'
 
-// CHECK: class-template-partial-spec1.cpp:38:8: warning: type 'IntTemplateSpec<5, void *>' has incompatible definitions in different translation units
+// CHECK: class-template-partial-spec1.cpp:38:8: error: type 'IntTemplateSpec<5, void *>' has incompatible definitions in different translation units
 // CHECK: class-template-partial-spec1.cpp:39:7: note: field 'member' has type 'int' here
 // CHECK: class-template-partial-spec2.cpp:39:10: note: field 'member' has type 'double' here
 

--- a/test/ASTMerge/class-template/test.cpp
+++ b/test/ASTMerge/class-template/test.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/class-template1.cpp
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/class-template2.cpp
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: class-template1.cpp:7:14: error: non-type template parameter declared with incompatible types in different translation units ('int' vs. 'long')
 // CHECK: class-template2.cpp:7:15: note: declared here with type 'long'
@@ -17,8 +17,8 @@
 // CHECK: class-template2.cpp:25:20: error: external variable 'x0r' declared with incompatible types in different translation units ('X0<double> *' vs. 'X0<float> *')
 // CHECK: class-template1.cpp:24:19: note: declared here with type 'X0<float> *'
 
-// CHECK: class-template1.cpp:32:8: warning: type 'X0<wchar_t>' has incompatible definitions in different translation units
+// CHECK: class-template1.cpp:32:8: error: type 'X0<wchar_t>' has incompatible definitions in different translation units
 // CHECK: class-template1.cpp:33:7: note: field 'member' has type 'int' here
 // CHECK: class-template2.cpp:34:9: note: field 'member' has type 'float' here
 
-// CHECK: 1 warning and 5 errors generated.
+// CHECK: 6 errors generated.

--- a/test/ASTMerge/class/Inputs/class_member_order.cpp
+++ b/test/ASTMerge/class/Inputs/class_member_order.cpp
@@ -1,0 +1,14 @@
+struct A {
+  int b = a + 2;
+  int c;
+  int a = 5;
+};
+
+struct B {
+  int f() {
+    return a + 2;
+  }
+  int b;
+  int c;
+  int a;
+};

--- a/test/ASTMerge/class/nothing.cpp
+++ b/test/ASTMerge/class/nothing.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/class_member_order.cpp -std=c++11
+// RUN: %clang_cc1 -ast-merge %t.1.ast -ast-print %s -std=c++11 2>&1 | FileCheck %s
+
+
+// CHECK: struct A {
+// CHECK-NEXT:    int b = this->a + 2;
+// CHECK-NEXT:    int c;
+// CHECK-NEXT:    int a = 5;
+// CHECK-NEXT:};
+// CHECK-NEXT:struct B {
+// CHECK-NEXT:    int f()     {
+// CHECK-NEXT:        return this->a + 2;
+// CHECK-NEXT:    }
+// CHECK-NEXT:    int b;
+// CHECK-NEXT:    int c;
+// CHECK-NEXT:    int a;
+// CHECK-NEXT:};

--- a/test/ASTMerge/enum/test.c
+++ b/test/ASTMerge/enum/test.c
@@ -1,25 +1,25 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/enum1.c
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/enum2.c
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
-// CHECK: enum1.c:9:6: warning: type 'enum E2' has incompatible definitions in different translation units
+// CHECK: enum1.c:9:6: error: type 'enum E2' has incompatible definitions in different translation units
 // CHECK: enum1.c:11:3: note: enumerator 'E2Enumerator2' with value 3 here
 // CHECK: enum2.c:11:3: note: enumerator 'E2Enumerator2' with value 4 here
 // CHECK: enum2.c:13:3: error: external variable 'x2' declared with incompatible types in different translation units ('enum E2' vs. 'enum E2')
 // CHECK: enum1.c:13:3: note: declared here with type 'enum E2'
-// CHECK: enum1.c:16:6: warning: type 'enum E3' has incompatible definitions in different translation units
+// CHECK: enum1.c:16:6: error: type 'enum E3' has incompatible definitions in different translation units
 // CHECK: enum1.c:18:3: note: enumerator 'E3Enumerator2' with value 3 here
 // CHECK: enum2.c:18:3: note: enumerator 'E3Enumerator' with value 3 here
 // CHECK: enum2.c:20:3: error: external variable 'x3' declared with incompatible types in different translation units ('enum E3' vs. 'enum E3')
 // CHECK: enum1.c:20:3: note: declared here with type 'enum E3'
-// CHECK: enum1.c:23:6: warning: type 'enum E4' has incompatible definitions in different translation units
+// CHECK: enum1.c:23:6: error: type 'enum E4' has incompatible definitions in different translation units
 // CHECK: enum1.c:26:3: note: enumerator 'E4Enumerator3' with value 2 here
 // CHECK: enum2.c:23:6: note: no corresponding enumerator here
 // CHECK: enum2.c:26:3: error: external variable 'x4' declared with incompatible types in different translation units ('enum E4' vs. 'enum E4')
 // CHECK: enum1.c:27:3: note: declared here with type 'enum E4'
-// CHECK: enum1.c:30:6: warning: type 'enum E5' has incompatible definitions in different translation units
+// CHECK: enum1.c:30:6: error: type 'enum E5' has incompatible definitions in different translation units
 // CHECK: enum2.c:33:3: note: enumerator 'E5Enumerator4' with value 3 here
 // CHECK: enum1.c:30:6: note: no corresponding enumerator here
 // CHECK: enum2.c:34:3: error: external variable 'x5' declared with incompatible types in different translation units ('enum E5' vs. 'enum E5')
 // CHECK: enum1.c:34:3: note: declared here with type 'enum E5'
-// CHECK: 4 warnings and 4 errors generated
+// CHECK: 8 errors generated

--- a/test/ASTMerge/function/test.c
+++ b/test/ASTMerge/function/test.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/function1.c
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/function2.c
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only -verify %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only -verify %s
 
 // CHECK: function2.c:3:6: error: external function 'f1' declared with incompatible types in different translation units ('void (Int, double)' (aka 'void (int, double)') vs. 'void (int, float)')
 // CHECK: function1.c:2:6: note: declared here with type 'void (int, float)'

--- a/test/ASTMerge/interface/test.m
+++ b/test/ASTMerge/interface/test.m
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/interface1.m
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/interface2.m
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: interface2.m:16:9: error: instance variable 'ivar2' declared with incompatible types in different translation units ('float' vs. 'int')
 // CHECK: interface1.m:16:7: note: declared here with type 'int'
@@ -9,14 +9,14 @@
 // CHECK: interface2.m:21:17: note: inherits from superclass 'I1' here
 // CHECK: interface2.m:33:1: error: class method 'foo' has incompatible result types in different translation units ('float' vs. 'int')
 // CHECK: interface1.m:34:1: note: class method 'foo' also declared here
-// CHECK: interface2.m:39:19: error: class method 'bar:' has a parameter with a different types in different translation units ('float' vs. 'int')
+// CHECK: interface2.m:39:19: warning: class method 'bar:' has a parameter with a different types in different translation units ('float' vs. 'int')
 // CHECK: interface1.m:40:17: note: declared here with type 'int'
 // CHECK: interface2.m:45:1: error: class method 'bar:' is variadic in one translation unit and not variadic in another
 // CHECK: interface1.m:46:1: note: class method 'bar:' also declared here
-// CHECK: interface2.m:57:20: error: instance method 'bar:' has a parameter with a different types in different translation units ('double' vs. 'float')
+// CHECK: interface2.m:57:20: warning: instance method 'bar:' has a parameter with a different types in different translation units ('double' vs. 'float')
 // CHECK: interface1.m:58:19: note: declared here with type 'float'
 // CHECK: interface1.m:100:17: error: class 'I15' has incompatible superclasses
 // CHECK: interface1.m:100:17: note: inherits from superclass 'I12' here
 // CHECK: interface2.m:99:17: note: inherits from superclass 'I11' here
-// CHECK: 8 errors generated
+// CHECK: 2 warnings and 6 errors generated
 

--- a/test/ASTMerge/namespace/test.cpp
+++ b/test/ASTMerge/namespace/test.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.1.ast %S/Inputs/namespace1.cpp
 // RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.2.ast %S/Inputs/namespace2.cpp
-// RUN: not %clang_cc1 -std=c++1z -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -std=c++1z -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 static_assert(TestAliasName::z == 4);
 static_assert(ContainsInline::z == 10);

--- a/test/ASTMerge/property/test.m
+++ b/test/ASTMerge/property/test.m
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/property1.m
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/property2.m
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: property2.m:12:26: error: property 'Prop1' declared with incompatible types in different translation units ('int' vs. 'float')
 // CHECK: property1.m:10:28: note: declared here with type 'float'

--- a/test/ASTMerge/struct/test.c
+++ b/test/ASTMerge/struct/test.c
@@ -1,55 +1,55 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/struct1.c
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/struct2.c
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
-// CHECK: struct1.c:13:8: warning: type 'struct S1' has incompatible definitions in different translation units
+// CHECK: struct1.c:13:8: error: type 'struct S1' has incompatible definitions in different translation units
 // CHECK: struct1.c:15:7: note: field 'field2' has type 'int' here
 // CHECK: struct2.c:12:9: note: field 'field2' has type 'float' here
 // CHECK: struct2.c:15:11: error: external variable 'x1' declared with incompatible types in different translation units ('struct S1' vs. 'struct S1')
 // CHECK: struct1.c:18:11: note: declared here with type 'struct S1'
-// CHECK: struct1.c:21:8: warning: type 'struct S2' has incompatible definitions in different translation units
+// CHECK: struct1.c:21:8: error: type 'struct S2' has incompatible definitions in different translation units
 // CHECK: struct2.c:18:7: note: 'S2' is a union here
 // CHECK: struct2.c:18:30: error: external variable 'x2' declared with incompatible types in different translation units ('union S2' vs. 'struct S2')
 // CHECK: struct1.c:21:31: note: declared here with type 'struct S2'
-// CHECK: struct1.c:24:8: warning: type 'struct S3' has incompatible definitions in different translation units
+// CHECK: struct1.c:24:8: error: type 'struct S3' has incompatible definitions in different translation units
 // CHECK: struct1.c:24:36: note: field 'd' has type 'double' here
 // CHECK: struct2.c:21:8: note: no corresponding field here
 // CHECK: struct2.c:21:31: error: external variable 'x3' declared with incompatible types in different translation units ('struct S3' vs. 'struct S3')
 // CHECK: struct1.c:24:41: note: declared here with type 'struct S3'
-// CHECK: struct1.c:27:8: warning: type 'struct S4' has incompatible definitions in different translation units
+// CHECK: struct1.c:27:8: error: type 'struct S4' has incompatible definitions in different translation units
 // CHECK: struct2.c:24:26: note: field 'f' has type 'float' here
 // CHECK: struct1.c:27:8: note: no corresponding field here
 // CHECK: struct2.c:24:31: error: external variable 'x4' declared with incompatible types in different translation units ('struct S4' vs. 'struct S4')
 // CHECK: struct1.c:27:22: note: declared here with type 'struct S4'
-// CHECK: struct1.c:33:8: warning: type 'struct S6' has incompatible definitions in different translation units
+// CHECK: struct1.c:33:8: error: type 'struct S6' has incompatible definitions in different translation units
 // CHECK: struct1.c:33:33: note: bit-field 'j' with type 'unsigned int' and length 8 here
 // CHECK: struct2.c:30:33: note: field 'j' is not a bit-field
 // CHECK: struct2.c:30:38: error: external variable 'x6' declared with incompatible types in different translation units ('struct S6' vs. 'struct S6')
 // CHECK: struct1.c:33:42: note: declared here with type 'struct S6'
-// CHECK: struct1.c:36:8: warning: type 'struct S7' has incompatible definitions in different translation units
+// CHECK: struct1.c:36:8: error: type 'struct S7' has incompatible definitions in different translation units
 // CHECK: struct1.c:36:33: note: bit-field 'j' with type 'unsigned int' and length 8 here
 // CHECK: struct2.c:33:33: note: bit-field 'j' with type 'unsigned int' and length 16 here
 // CHECK: struct2.c:33:43: error: external variable 'x7' declared with incompatible types in different translation units ('struct S7' vs. 'struct S7')
 // CHECK: struct1.c:36:42: note: declared here with type 'struct S7'
-// CHECK: struct1.c:56:10: warning: type 'struct DeeperError' has incompatible definitions in different translation units
+// CHECK: struct1.c:56:10: error: type 'struct DeeperError' has incompatible definitions in different translation units
 // CHECK: struct1.c:56:35: note: field 'f' has type 'int' here
 // CHECK: struct2.c:53:37: note: field 'f' has type 'float' here
-// CHECK: struct1.c:54:8: warning: type 'struct DeepError' has incompatible definitions in different translation units
+// CHECK: struct1.c:54:8: error: type 'struct DeepError' has incompatible definitions in different translation units
 // CHECK: struct1.c:56:41: note: field 'Deeper' has type 'struct DeeperError *' here
 // CHECK: struct2.c:53:43: note: field 'Deeper' has type 'struct DeeperError *' here
 // CHECK: struct2.c:54:3: error: external variable 'xDeep' declared with incompatible types in different translation units ('struct DeepError' vs. 'struct DeepError')
 // CHECK: struct1.c:57:3: note: declared here with type 'struct DeepError'
-// CHECK: struct1.c:74:9: warning: type 'S13' has incompatible definitions in different translation units
+// CHECK: struct1.c:74:9: error: type 'S13' has incompatible definitions in different translation units
 // CHECK: struct1.c:75:9: note: field 'i' has type 'Float' (aka 'float') here
 // CHECK: struct2.c:72:7: note: field 'i' has type 'int' here
 // CHECK: struct2.c:76:5: error: external variable 'x13' declared with incompatible types in different translation units ('S13' vs. 'S13')
 // CHECK: struct1.c:79:5: note: declared here with type 'S13'
-// CHECK: struct1.c:130:7: warning: type 'struct DeepUnnamedError::(anonymous at [[PATH_TO_INPUTS:.+]]/struct1.c:130:7)' has incompatible definitions in different translation units
+// CHECK: struct1.c:130:7: error: type 'struct DeepUnnamedError::(anonymous at [[PATH_TO_INPUTS:.+]]/struct1.c:130:7)' has incompatible definitions in different translation units
 // CHECK: struct1.c:131:14: note: field 'i' has type 'long' here
 // CHECK: struct2.c:128:15: note: field 'i' has type 'float' here
-// CHECK: struct1.c:129:5: warning: type 'union DeepUnnamedError::(anonymous at [[PATH_TO_INPUTS]]/struct1.c:129:5)' has incompatible definitions in different translation units
+  // CHECK: struct1.c:129:5: error: type 'union DeepUnnamedError::(anonymous at [[PATH_TO_INPUTS]]/struct1.c:129:5)' has incompatible definitions in different translation units
 // CHECK: struct1.c:132:9: note: field 'S' has type 'struct (anonymous struct at [[PATH_TO_INPUTS]]/struct1.c:130:7)' here
 // CHECK: struct2.c:129:9: note: field 'S' has type 'struct (anonymous struct at [[PATH_TO_INPUTS]]/struct2.c:127:7)' here
 // CHECK: struct2.c:138:3: error: external variable 'x16' declared with incompatible types in different translation units ('struct DeepUnnamedError' vs. 'struct DeepUnnamedError')
 // CHECK: struct1.c:141:3: note: declared here with type 'struct DeepUnnamedError'
-// CHECK: 11 warnings and 10 errors generated
+// CHECK: 21 errors generated

--- a/test/ASTMerge/typedef/test.c
+++ b/test/ASTMerge/typedef/test.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/typedef1.c
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/typedef2.c
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: typedef2.c:4:10: error: external variable 'x2' declared with incompatible types in different translation units ('Typedef2' (aka 'double') vs. 'Typedef2' (aka 'int'))
 // CHECK: typedef1.c:4:10: note: declared here with type 'Typedef2' (aka 'int')

--- a/test/ASTMerge/var/test.c
+++ b/test/ASTMerge/var/test.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/var1.c
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/var2.c
-// RUN: not %clang_cc1 -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only -fdiagnostics-show-note-include-stack %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -Werror -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only -fdiagnostics-show-note-include-stack %s 2>&1 | FileCheck %s
 
 // CHECK: var2.c:2:9: error: external variable 'x1' declared with incompatible types in different translation units ('double *' vs. 'float **')
 // CHECK: var1.c:2:9: note: declared here with type 'float **'


### PR DESCRIPTION
This commit also fixes tests which were failing because we converted some errors into warnings.