### PR TITLE
Fix a crash due to invalid file ids

### DIFF
--- a/lib/StaticAnalyzer/Core/PathDiagnostic.cpp
+++ b/lib/StaticAnalyzer/Core/PathDiagnostic.cpp
@@ -388,8 +388,11 @@ static bool compareCrossTUSourceLocs(FullSourceLoc XL, FullSourceLoc YL) {
   std::pair<bool, bool> InSameTU = SM.isInTheSameTranslationUnit(XOffs, YOffs);
   if (InSameTU.first)
     return XL.isBeforeInTranslationUnitThan(YL);
-  return SM.getFileEntryForID(XL.getFileID())->getName() <
-         SM.getFileEntryForID(YL.getFileID())->getName();
+  const FileEntry *XFE = SM.getFileEntryForID(XL.getFileID());
+  const FileEntry *YFE = SM.getFileEntryForID(YL.getFileID());
+  if (!XFE || !YFE)
+    return XFE && !YFE;
+  return XFE->getName() < YFE->getName();
 }
 
 static bool compare(const PathDiagnostic &X, const PathDiagnostic &Y) {


### PR DESCRIPTION
We experienced a regression on the number of successes when analyzing vim. There were some crashes during emitting the reports due to sometimes we could not query the corresponding file entry for a source location. Unfortunately, it is very hard to synthesize a test case for this problem, but I tested this code on vim and it seems to solve the problem.