### PR TITLE
Track functions with unsupported AST nodes

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -88,6 +88,7 @@ namespace clang {
     /// This flag signs if the Importer encountered an unsupported node during
     /// the last import process.
     bool encounteredUnsupportedNode;
+
   public:
     /// \brief Create a new AST importer.
     ///
@@ -319,11 +320,8 @@ namespace clang {
       encounteredUnsupportedNode = B;
     }
 
-    bool hasEncounteredUnsupportedNode() {
-      return encounteredUnsupportedNode;
-    }
+    bool hasEncounteredUnsupportedNode() { return encounteredUnsupportedNode; }
   };
-
 }
 
 #endif // LLVM_CLANG_AST_ASTIMPORTER_H

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -84,7 +84,10 @@ namespace clang {
     /// \brief Declaration (from, to) pairs that are known not to be equivalent
     /// (which we have already complained about).
     NonEquivalentDeclSet NonEquivalentDecls;
-    
+
+    /// This flag signs if the Importer encountered an unsupported node during
+    /// the last import process.
+    bool encounteredUnsupportedNode;
   public:
     /// \brief Create a new AST importer.
     ///
@@ -311,7 +314,16 @@ namespace clang {
     /// equivalent.
     bool IsStructurallyEquivalent(QualType From, QualType To,
                                   bool Complain = true);
+
+    void setEncounteredUnsupportedNode(bool B) {
+      encounteredUnsupportedNode = B;
+    }
+
+    bool hasEncounteredUnsupportedNode() {
+      return encounteredUnsupportedNode;
+    }
   };
+
 }
 
 #endif // LLVM_CLANG_AST_ASTIMPORTER_H

--- a/include/clang/Tooling/CrossTranslationUnit.h
+++ b/include/clang/Tooling/CrossTranslationUnit.h
@@ -15,8 +15,8 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringMap.h"
 
 namespace clang {
 class CompilerInstance;
@@ -67,6 +67,7 @@ public:
   /// Returns if FD is an imported function which import process encountered an
   /// unsupported AST node.
   bool isInvalidFunction(const FunctionDecl *FD);
+
 private:
   ASTImporter &getOrCreateASTImporter(ASTContext &From);
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,

--- a/include/clang/Tooling/CrossTranslationUnit.h
+++ b/include/clang/Tooling/CrossTranslationUnit.h
@@ -16,6 +16,7 @@
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace clang {
 class CompilerInstance;
@@ -62,6 +63,7 @@ public:
                                            StringRef CompilationDatabase = "");
 
   std::string getLookupName(const NamedDecl *ND);
+  bool isInvalidFunction(const FunctionDecl *FD);
 private:
   ASTImporter &getOrCreateASTImporter(ASTContext &From);
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,
@@ -72,6 +74,7 @@ private:
   llvm::StringMap<std::string> FunctionFileMap;
   llvm::DenseMap<TranslationUnitDecl *, std::unique_ptr<ASTImporter>>
       ASTUnitImporterMap;
+  llvm::SmallPtrSet<const FunctionDecl *, 8> InvalidFunctions;
   CompilerInstance &CI;
   ASTContext &Context;
 };

--- a/include/clang/Tooling/CrossTranslationUnit.h
+++ b/include/clang/Tooling/CrossTranslationUnit.h
@@ -63,6 +63,9 @@ public:
                                            StringRef CompilationDatabase = "");
 
   std::string getLookupName(const NamedDecl *ND);
+
+  /// Returns if FD is an imported function which import process encountered an
+  /// unsupported AST node.
   bool isInvalidFunction(const FunctionDecl *FD);
 private:
   ASTImporter &getOrCreateASTImporter(ASTContext &From);

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -353,6 +353,7 @@ using namespace clang;
 QualType ASTNodeImporter::VisitType(const Type *T) {
   Importer.FromDiag(SourceLocation(), diag::err_unsupported_ast_node)
     << T->getTypeClassName();
+  Importer.setEncounteredUnsupportedNode(true);
   return QualType();
 }
 
@@ -1378,6 +1379,7 @@ bool ASTNodeImporter::IsStructuralMatch(VarTemplateDecl *From,
 Decl *ASTNodeImporter::VisitDecl(Decl *D) {
   Importer.FromDiag(D->getLocation(), diag::err_unsupported_ast_node)
     << D->getDeclKindName();
+  Importer.setEncounteredUnsupportedNode(true);
   return nullptr;
 }
 
@@ -4320,6 +4322,7 @@ DeclGroupRef ASTNodeImporter::ImportDeclGroup(DeclGroupRef DG) {
  Stmt *ASTNodeImporter::VisitStmt(Stmt *S) {
    Importer.FromDiag(S->getLocStart(), diag::err_unsupported_ast_node)
      << S->getStmtClassName();
+   Importer.setEncounteredUnsupportedNode(true);
    return nullptr;
  }
 
@@ -6238,7 +6241,8 @@ ASTImporter::ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
                          bool MinimalImport)
   : ToContext(ToContext), FromContext(FromContext),
     ToFileManager(ToFileManager), FromFileManager(FromFileManager),
-    Minimal(MinimalImport), LastDiagFromFrom(false)
+    Minimal(MinimalImport), LastDiagFromFrom(false),
+    encounteredUnsupportedNode(false)
 {
   ImportedDecls[FromContext.getTranslationUnitDecl()]
     = ToContext.getTranslationUnitDecl();

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -6239,11 +6239,10 @@ void ASTNodeImporter::ImportOverrides(CXXMethodDecl *ToMethod,
 ASTImporter::ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
                          ASTContext &FromContext, FileManager &FromFileManager,
                          bool MinimalImport)
-  : ToContext(ToContext), FromContext(FromContext),
-    ToFileManager(ToFileManager), FromFileManager(FromFileManager),
-    Minimal(MinimalImport), LastDiagFromFrom(false),
-    encounteredUnsupportedNode(false)
-{
+    : ToContext(ToContext), FromContext(FromContext),
+      ToFileManager(ToFileManager), FromFileManager(FromFileManager),
+      Minimal(MinimalImport), LastDiagFromFrom(false),
+      encounteredUnsupportedNode(false) {
   ImportedDecls[FromContext.getTranslationUnitDecl()]
     = ToContext.getTranslationUnitDecl();
 }

--- a/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -793,7 +793,7 @@ bool ExprEngine::shouldInlineCall(const CallEvent &Call, const Decl *D,
   if (!D)
     return false;
 
-  if(CTU.isInvalidFunction(dyn_cast<FunctionDecl>(D)))
+  if (CTU.isInvalidFunction(dyn_cast<FunctionDecl>(D)))
     return false;
 
   AnalysisManager &AMgr = getAnalysisManager();

--- a/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -19,6 +19,7 @@
 #include "clang/Analysis/Analyses/LiveVariables.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
+#include "clang/Tooling/CrossTranslationUnit.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -790,6 +791,9 @@ static bool mayInlineDecl(AnalysisDeclContext *CalleeADC,
 bool ExprEngine::shouldInlineCall(const CallEvent &Call, const Decl *D,
                                   const ExplodedNode *Pred) {
   if (!D)
+    return false;
+
+  if(CTU.isInvalidFunction(dyn_cast<FunctionDecl>(D)))
     return false;
 
   AnalysisManager &AMgr = getAnalysisManager();

--- a/lib/Tooling/CrossTranslationUnit.cpp
+++ b/lib/Tooling/CrossTranslationUnit.cpp
@@ -39,6 +39,8 @@ STATISTIC(
 STATISTIC(NumIterateNotFound, "The # of iteration not found");
 STATISTIC(NumGetCTUSuccess, "The # of getCTUDefinition successfully return the "
                             "requested function's body");
+STATISTIC(NumUnsupportedNodeFound, "The # of imports when the ASTImporter "
+                                   "encountered an unsupported AST Node");
 }
 
 namespace clang {
@@ -196,6 +198,7 @@ const FunctionDecl *CrossTranslationUnit::getCrossTUDefinition(
     if(Importer.hasEncounteredUnsupportedNode()){
       InvalidFunctions.insert(ToDecl);
       Importer.setEncounteredUnsupportedNode(false);
+      NumUnsupportedNodeFound++;
       return nullptr;
     }
     assert(ToDecl->hasBody());

--- a/lib/Tooling/CrossTranslationUnit.cpp
+++ b/lib/Tooling/CrossTranslationUnit.cpp
@@ -195,7 +195,7 @@ const FunctionDecl *CrossTranslationUnit::getCrossTUDefinition(
           findFunctionInDeclContext(TU, LookupFnName)) {
     auto *ToDecl = cast<FunctionDecl>(
         Importer.Import(const_cast<FunctionDecl *>(ResultDecl)));
-    if(Importer.hasEncounteredUnsupportedNode()){
+    if (Importer.hasEncounteredUnsupportedNode()) {
       InvalidFunctions.insert(ToDecl);
       Importer.setEncounteredUnsupportedNode(false);
       NumUnsupportedNodeFound++;
@@ -221,8 +221,7 @@ ASTImporter &CrossTranslationUnit::getOrCreateASTImporter(ASTContext &From) {
   return *NewImporter;
 }
 
-bool CrossTranslationUnit::isInvalidFunction(const FunctionDecl* FD)
-{
+bool CrossTranslationUnit::isInvalidFunction(const FunctionDecl *FD) {
   return InvalidFunctions.find(FD) != InvalidFunctions.end();
 }
 

--- a/lib/Tooling/CrossTranslationUnit.cpp
+++ b/lib/Tooling/CrossTranslationUnit.cpp
@@ -193,6 +193,11 @@ const FunctionDecl *CrossTranslationUnit::getCrossTUDefinition(
           findFunctionInDeclContext(TU, LookupFnName)) {
     auto *ToDecl = cast<FunctionDecl>(
         Importer.Import(const_cast<FunctionDecl *>(ResultDecl)));
+    if(Importer.hasEncounteredUnsupportedNode()){
+      InvalidFunctions.insert(ToDecl);
+      Importer.setEncounteredUnsupportedNode(false);
+      return nullptr;
+    }
     assert(ToDecl->hasBody());
     assert(FD->hasBody() && "Functions already imported should have body.");
     ++NumGetCTUSuccess;
@@ -211,6 +216,11 @@ ASTImporter &CrossTranslationUnit::getOrCreateASTImporter(ASTContext &From) {
                       From, From.getSourceManager().getFileManager(), false);
   ASTUnitImporterMap[From.getTranslationUnitDecl()].reset(NewImporter);
   return *NewImporter;
+}
+
+bool CrossTranslationUnit::isInvalidFunction(const FunctionDecl* FD)
+{
+  return InvalidFunctions.find(FD) != InvalidFunctions.end();
 }
 
 } // namespace tooling

--- a/test/Analysis/Inputs/externalFnMap_usr.txt
+++ b/test/Analysis/Inputs/externalFnMap_usr.txt
@@ -13,3 +13,4 @@ c:@F@h#I# xtu-other.cpp.ast
 c:@F@h_chain#I# xtu-chain.cpp.ast
 c:@N@chns@S@chcls@F@chf4#I# xtu-chain.cpp.ast
 c:@N@chns@F@chf2#I# xtu-chain.cpp.ast
+c:@F@fun_with_unsupported_node#I# xtu-other.cpp.ast

--- a/test/Analysis/Inputs/xtu-other.cpp
+++ b/test/Analysis/Inputs/xtu-other.cpp
@@ -76,9 +76,10 @@ int avtSize(void){
 	return sizeof(avt);
 }
 
-template <typename T> class X { T t; };
+template <typename T>
+class X { T t; };
 
-int fun_with_unsupported_node(){
+int fun_with_unsupported_node() {
   using typeAliasDecl = X<int>;
   return 0;
 }

--- a/test/Analysis/Inputs/xtu-other.cpp
+++ b/test/Analysis/Inputs/xtu-other.cpp
@@ -75,3 +75,10 @@ typedef struct AVBuffer avt;
 int avtSize(void){
 	return sizeof(avt);
 }
+
+template <typename T> class X { T t; };
+
+int fun_with_unsupported_node(){
+  using typeAliasDecl = X<int>;
+  return 0;
+}

--- a/test/Analysis/Inputs/xtu-other.cpp
+++ b/test/Analysis/Inputs/xtu-other.cpp
@@ -79,7 +79,11 @@ int avtSize(void){
 template <typename T>
 class X { T t; };
 
-int fun_with_unsupported_node() {
-  using typeAliasDecl = X<int>;
-  return 0;
+template <typename T, int Size> class vector {
+  typedef T __attribute__((ext_vector_type(Size))) type;
+};
+// DependentSizedExtVectorType import is not supported yet.
+int fun_with_unsupported_node(int n) {
+  vector<int,8> v;
+  return n;
 }

--- a/test/Analysis/xtu-main_usr.cpp
+++ b/test/Analysis/xtu-main_usr.cpp
@@ -44,7 +44,7 @@ int chf1(int x);
 typedef struct AVBuffer avt;
 int avtSize(void);
 
-int fun_with_unsupported_node();
+int fun_with_unsupported_node(int);
 
 int main() {
   clang_analyzer_eval(f(3) == 2); // expected-warning{{TRUE}}
@@ -62,7 +62,7 @@ int main() {
   clang_analyzer_eval(avtSize() == 4); // expected-warning{{TRUE}}
 
   // First time, when the import of the function with unsupported node happens.
-  clang_analyzer_eval(fun_with_unsupported_node() == 0); // expected-warning{{UNKNOWN}}
+  clang_analyzer_eval(fun_with_unsupported_node(0) == 0); // expected-warning{{UNKNOWN}}
   // When it is already imported.
-  clang_analyzer_eval(fun_with_unsupported_node() == 0); // expected-warning{{UNKNOWN}}
+  clang_analyzer_eval(fun_with_unsupported_node(0) == 0); // expected-warning{{UNKNOWN}}
 }

--- a/test/Analysis/xtu-main_usr.cpp
+++ b/test/Analysis/xtu-main_usr.cpp
@@ -2,7 +2,7 @@
 // RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/xtudir/xtu-other.cpp.ast %S/Inputs/xtu-other.cpp
 // RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/xtudir/xtu-chain.cpp.ast %S/Inputs/xtu-chain.cpp
 // RUN: cp %S/Inputs/externalFnMap_usr.txt %T/xtudir/externalFnMap.txt
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config xtu-dir=%T/xtudir -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config xtu-dir=%T/xtudir -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -std=c++11 -verify %s
 
 void clang_analyzer_eval(int);
 
@@ -44,6 +44,8 @@ int chf1(int x);
 typedef struct AVBuffer avt;
 int avtSize(void);
 
+int fun_with_unsupported_node();
+
 int main() {
   clang_analyzer_eval(f(3) == 2); // expected-warning{{TRUE}}
   clang_analyzer_eval(f(4) == 3); // expected-warning{{TRUE}}
@@ -58,4 +60,9 @@ int main() {
   clang_analyzer_eval(mycls::embed_cls2().fecl2(0) == -11); // expected-warning{{TRUE}}
   clang_analyzer_eval(chns::chf1(4) == 12); // expected-warning{{TRUE}}
   clang_analyzer_eval(avtSize() == 4); // expected-warning{{TRUE}}
+
+  // First time, when the import of the function with unsupported node happens.
+  clang_analyzer_eval(fun_with_unsupported_node() == 0); // expected-warning{{UNKNOWN}}
+  // When it is already imported.
+  clang_analyzer_eval(fun_with_unsupported_node() == 0); // expected-warning{{UNKNOWN}}
 }


### PR DESCRIPTION
This way the analyzer won't inline the badly imported functions with unsupported AST nodes.