### PR TITLE
Display loaded files for ctu analysis

### DIFF
--- a/include/clang/Driver/CC1Options.td
+++ b/include/clang/Driver/CC1Options.td
@@ -81,6 +81,9 @@ def analyzer_viz_egraph_graphviz : Flag<["-"], "analyzer-viz-egraph-graphviz">,
 def analyzer_viz_egraph_ubigraph : Flag<["-"], "analyzer-viz-egraph-ubigraph">,
   HelpText<"Display exploded graph using Ubigraph">;
 
+def analyzer_display_ctu_progress : Flag<["-"], "analyzer-display-ctu-progress">,
+  HelpText<"Emit verbose output about the analyzer's progress related to ctu">;
+
 def analyzer_inline_max_stack_depth : Separate<["-"], "analyzer-inline-max-stack-depth">,
   HelpText<"Bound on stack depth while inlining (4 by default)">;
 def analyzer_inline_max_stack_depth_EQ : Joined<["-"], "analyzer-inline-max-stack-depth=">, 

--- a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+++ b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
@@ -155,6 +155,7 @@ public:
   unsigned ShowEnabledCheckerList : 1;
   unsigned AnalyzeAll : 1;
   unsigned AnalyzerDisplayProgress : 1;
+  unsigned AnalyzerDisplayCtuProgress : 1;
   unsigned AnalyzeNestedBlocks : 1;
 
   /// \brief The flag regulates if we should eagerly assume evaluations of
@@ -600,6 +601,7 @@ public:
     ShowEnabledCheckerList(0),
     AnalyzeAll(0),
     AnalyzerDisplayProgress(0),
+    AnalyzerDisplayCtuProgress(0),
     AnalyzeNestedBlocks(0),
     eagerlyAssumeBinOpBifurcation(0),
     TrimGraph(0),

--- a/include/clang/Tooling/CrossTranslationUnit.h
+++ b/include/clang/Tooling/CrossTranslationUnit.h
@@ -60,7 +60,8 @@ public:
   const FunctionDecl *getCrossTUDefinition(const FunctionDecl *FD,
                                            StringRef CrossTUDir,
                                            StringRef IndexName,
-                                           StringRef CompilationDatabase = "");
+                                           StringRef CompilationDatabase = "",
+                                           bool DisplayCtuProgress = false);
 
   std::string getLookupName(const NamedDecl *ND);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -262,6 +262,8 @@ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
   Opts.InlineMaxStackDepth =
       getLastArgIntValue(Args, OPT_analyzer_inline_max_stack_depth,
                          Opts.InlineMaxStackDepth, Diags);
+  Opts.AnalyzerDisplayCtuProgress =
+      Args.hasArg(OPT_analyzer_display_ctu_progress);
 
   Opts.CheckersControlList.clear();
   for (const Arg *A :

--- a/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -383,7 +383,8 @@ RuntimeDefinition AnyFunctionCall::getRuntimeDefinition() const {
 
   const FunctionDecl *CTUDecl = CTU.getCrossTUDefinition(
       FD, AMgr.options.getCTUDir(), "externalFnMap.txt",
-      AMgr.options.getCTUReparseOnDemand());
+      AMgr.options.getCTUReparseOnDemand(),
+      AMgr.options.AnalyzerDisplayCtuProgress);
 
   return RuntimeDefinition(CTUDecl);
 }

--- a/lib/Tooling/CrossTranslationUnit.cpp
+++ b/lib/Tooling/CrossTranslationUnit.cpp
@@ -84,7 +84,7 @@ CrossTranslationUnit::findFunctionInDeclContext(const DeclContext *DC,
 
 const FunctionDecl *CrossTranslationUnit::getCrossTUDefinition(
     const FunctionDecl *FD, StringRef CrossTUDir, StringRef IndexName,
-    StringRef CompilationDatabase) {
+    StringRef CompilationDatabase, bool DisplayCtuProgress) {
   assert(!FD->hasBody() && "FD has a definition in current translation unit!");
   ++NumGetCTUCalled;
 
@@ -175,6 +175,14 @@ const FunctionDecl *CrossTranslationUnit::getCrossTUDefinition(
       }
       Unit = LoadedUnit.get();
       FileASTUnitMap[ASTFileName] = std::move(LoadedUnit);
+
+      if (DisplayCtuProgress) {
+        // Drop the '.ast' extension
+        StringRef SourceFileName = ASTFileName.drop_back(4);
+        llvm::errs() << "ANALYZE (CTU loaded AST for source file): "
+                     << SourceFileName << "\n";
+      }
+
     } else {
       Unit = ASTCacheEntry->second.get();
     }

--- a/test/Analysis/xtu-main_usr.cpp
+++ b/test/Analysis/xtu-main_usr.cpp
@@ -3,6 +3,11 @@
 // RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/xtudir/xtu-chain.cpp.ast %S/Inputs/xtu-chain.cpp
 // RUN: cp %S/Inputs/externalFnMap_usr.txt %T/xtudir/externalFnMap.txt
 // RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config xtu-dir=%T/xtudir -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -std=c++11 -verify %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config xtu-dir=%T/xtudir -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -std=c++11 -analyzer-display-ctu-progress 2>&1 %s | FileCheck %s
+
+// CHECK: ANALYZE (CTU loaded AST for source file): {{.*}}/xtu-other.cpp
+// CHECK: ANALYZE (CTU loaded AST for source file): {{.*}}/xtu-chain.cpp
+
 
 void clang_analyzer_eval(int);
 


### PR DESCRIPTION
During CTU, if a function definition is needed from another TU and the
pch dump is present we display the name of the source file from which
the dump is generated (.ast extension removed).
This is needed to be able to collect those TUs which are used during the
analysis; in case of a crash we can package these files into the failure
zip.