### PR TITLE
ASTImport crash fix importing struct in function params

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -934,20 +934,22 @@ bool ASTNodeImporter::ImportDeclParts(NamedDecl *D, DeclContext *&DC,
   // Check if RecordDecl is in FunctionDecl parameters to avoid infinite loop.
   // example: int struct_in_proto(struct data_t{int a;int b;} *d);
   DeclContext *OrigDC = D->getDeclContext();
-  if(isa<RecordDecl>(D) && OrigDC->isFunctionOrMethod()) {
-    FunctionDecl *FunDecl = dyn_cast<FunctionDecl>(OrigDC);
-    if (FunDecl && FunDecl->hasBody()) {
+  FunctionDecl *FunDecl;
+  if (isa<RecordDecl>(D) && (FunDecl = dyn_cast<FunctionDecl>(OrigDC))) {
+    bool DoNotImport = !FunDecl->hasBody();
+    if (!DoNotImport) {
       SourceRange RecR = D->getSourceRange();
       SourceRange BodyR = FunDecl->getBody()->getSourceRange();
       // If RecordDecl is not in Body (it is a param), we bail out.
-      if (RecR.isValid() && BodyR.isValid() &&
-            (RecR.getBegin() < BodyR.getBegin() ||
-             BodyR.getEnd() < RecR.getEnd())) {
-        Importer.FromDiag(D->getLocation(), diag::err_unsupported_ast_node)
-              << D->getDeclKindName();
-        Importer.setEncounteredUnsupportedNode(true);
-        return true;
-      }
+      DoNotImport = RecR.isValid() && BodyR.isValid() &&
+                    (RecR.getBegin() < BodyR.getBegin() ||
+                     BodyR.getEnd() < RecR.getEnd());
+    }
+    if (DoNotImport) {
+      Importer.FromDiag(D->getLocation(), diag::err_unsupported_ast_node)
+          << D->getDeclKindName();
+      Importer.setEncounteredUnsupportedNode(true);
+      return true;
     }
   }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -932,6 +932,7 @@ bool ASTNodeImporter::ImportDeclParts(NamedDecl *D, DeclContext *&DC,
                                       NamedDecl *&ToD,
                                       SourceLocation &Loc) {
   // Check if RecordDecl is in FunctionDecl parameters to avoid infinite loop.
+  // example: int struct_in_proto(struct data_t{int a;int b;} *d);
   DeclContext *OrigDC = D->getDeclContext();
   if(isa<RecordDecl>(D) && OrigDC->isFunctionOrMethod()) {
     FunctionDecl *FunDecl = dyn_cast<FunctionDecl>(OrigDC);

--- a/lib/Tooling/CrossTranslationUnit.cpp
+++ b/lib/Tooling/CrossTranslationUnit.cpp
@@ -250,15 +250,16 @@ const FunctionDecl *CrossTranslationUnit::getCrossTUDefinition(
   TranslationUnitDecl *TU = Unit->getASTContext().getTranslationUnitDecl();
   if (const FunctionDecl *ResultDecl =
           findFunctionInDeclContext(TU, LookupFnName)) {
-    auto *ToDecl = cast<FunctionDecl>(
+    auto *ToDecl = cast_or_null<FunctionDecl>(
         Importer.Import(const_cast<FunctionDecl *>(ResultDecl)));
     if (Importer.hasEncounteredUnsupportedNode()) {
-      InvalidFunctions.insert(ToDecl);
+      if (ToDecl)
+        InvalidFunctions.insert(ToDecl);
       Importer.setEncounteredUnsupportedNode(false);
       NumUnsupportedNodeFound++;
       return nullptr;
     }
-    assert(ToDecl->hasBody());
+    assert(ToDecl && ToDecl->hasBody());
     assert(FD->hasBody() && "Functions already imported should have body.");
     ++NumGetCTUSuccess;
     return ToDecl;

--- a/test/Analysis/Inputs/xtu-other.c
+++ b/test/Analysis/Inputs/xtu-other.c
@@ -45,7 +45,7 @@ int ident_implicit(int in){
     return in;
 }
 
-//ASTImporter crashes on this
-//int struct_in_proto(struct data_t{int a;int b;} *d){
-//  return 0;
-//}
+//ASTImporter doesn't support this
+int struct_in_proto(struct data_t{int a;int b;} *d){
+  return 0;
+}

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -625,6 +625,16 @@ TEST(ImportExpr, ImportTypeTraitExprValDep) {
                                            )))))))))));
 }
 
+TEST(ImportDecl, ImportRecordDeclInFuncParams) {
+  MatchVerifier<Decl> Verifier;
+  EXPECT_TRUE(
+        testImport(
+          "int declToImport(struct data_t{int a;int b;} *d){ return 0; }",
+          Lang_CXX, "", Lang_CXX, Verifier,
+          functionDecl()));
+}
+
+
 TEST(ImportDecl, ImportFunctionTemplateDecl) {
   MatchVerifier<Decl> Verifier;
   EXPECT_TRUE(


### PR DESCRIPTION
Importing such a recursive structure is impossible without architectural changes in the importer. But this fix avoids crash and registers the problem.