### PR TITLE
Support field "arguments" in the compilation database json file

### DIFF
--- a/tools/xtu-build-new/xtu-analyze.py
+++ b/tools/xtu-build-new/xtu-analyze.py
@@ -136,6 +136,14 @@ def check_executable_available(exe_name, arg_path):
             'argument' if arg_path is not None else 'environment')
     return found_path
 
+def get_command_from_arguments(arguments):
+    command_tmp = ""
+    arguments.reverse()
+    while len(arguments) > 0:
+        opt = arguments.pop()
+        command_tmp += opt + " "
+    command_tmp.rstrip(" ")
+    return command_tmp  
 
 clang_path = check_executable_available('clang', mainargs.clang_path)
 analyze_path = check_executable_available('analyze-cc', mainargs.analyze_path)
@@ -195,6 +203,15 @@ passed_buildlog = []
 dircmd_2_original_orders = {}
 for step in buildlog:
     if src_pattern.match(step['file']):
+        if 'command' not in step:
+            if 'arguments' in step:
+                # change arguments to command
+                command_from_arg = get_command_from_arguments(step['arguments'])
+                step['command'] = command_from_arg
+            else:
+                print "have no field \"command\" and \"arguments\" to deal, exit..."
+                exit(2)
+                
         uid = step['directory'] + dircmd_separator + step['command']
         if uid not in dircmd_2_orders:
             dircmd_2_orders[uid] = [src_build_steps]

--- a/tools/xtu-build-new/xtu-build.py
+++ b/tools/xtu-build-new/xtu-build.py
@@ -83,6 +83,14 @@ def check_executable_available(exe_name, arg_path):
             'argument' if arg_path is not None else 'environment')
     return found_path
 
+def get_command_from_arguments(arguments):
+    command_tmp = ""
+    arguments.reverse()
+    while len(arguments) > 0:
+        opt = arguments.pop()
+        command_tmp += opt + " "
+    command_tmp.rstrip(" ")
+    return command_tmp
 
 clang_path = check_executable_available('clang', mainargs.clang_path)
 
@@ -98,6 +106,15 @@ cmd_2_src = {}
 cmd_order = []
 for step in buildlog:
     if src_pattern.match(step['file']):
+        if 'command' not in step:
+            if 'arguments' in step:
+                # change arguments to command
+                command_from_arg = get_command_from_arguments(step['arguments'])
+                step['command'] = command_from_arg
+            else:
+                print "have no field \"command\" and \"arguments\" to deal, exit..."
+                exit(2)
+                
         if step['file'] not in src_2_dir:
             src_2_dir[step['file']] = step['directory']
         if step['file'] not in src_2_cmd:


### PR DESCRIPTION
project: https://github.com/rizsotto/Bear
is a tool that capture compile command with gnu make(not cmake), and create the compilation database json file with field "arguments"(not "command").

xtu-build.py and xtu-analyze.py does not support field "arguments" in the  compilation database json file, so I adapt the "arguments" to "command"  for the original procedure.