### PR TITLE
Remove Decl from DeclContext only if present

### DIFF
--- a/include/clang/Basic/DiagnosticASTKinds.td
+++ b/include/clang/Basic/DiagnosticASTKinds.td
@@ -287,4 +287,6 @@ def err_odr_non_type_parameter_type_inconsistent : Warning<
   "non-type template parameter declared with incompatible types in different "
   "translation units (%0 vs. %1)">, InGroup<OdrDiags>;
 def err_unsupported_ast_node: Warning<"cannot import unsupported AST node %0">;
+def warn_ast_importer_missing_decl_in_decl_context : Warning<
+  "missing %0Decl in imported DeclContext <%1:%2:%3>">;
 }


### PR DESCRIPTION
This PR gives a warning when we want to remove a `Decl` from a `DeclContext` where it is not present (in `ImportDeclContext()`). We do not try to remove the unlinked `Decl` (and fail), rather we just issue the warning and we go on. We assume the information given in the warnings will guide us towards which AST nodes are imported wrongly into a `DeclContext`. These may be independent cases.
During minilink analysis I received the following missing declarations:
```
ANALYZE (CTU loaded AST for source file): ./report_debug/ctu-dir/powerpc/ast/home/egbomrt/WORK/DebugCrashes/minilink/reports/bns__2018_01_17__11_48_26/failed/UpgradeManager.cc_eb08be5f0e35d8a98c17ce0ecb505989/sources-root/local/scratch/repos/ML66/ml66_nps/nps/bns_app_src/platform/eqm/su/src/Snmp.cc
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: CXXMethod
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: FunctionTemplate
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: CXXRecord
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
warning: Missing Decl in imported DeclContext. Decl: ClassTemplateSpecialization
clang-5.0: ../../git/llvm/tools/clang/include/clang/AST/DeclBase.h:1040: void clang::Decl::setObjectOfFriendDecl(bool): Assertion `!(OldNS & ~(IDNS_Tag | IDNS_Ordinary | IDNS_Type | IDNS_TagFriend | IDNS_OrdinaryFriend | IDNS_LocalExtern)) && "namespace includes other than ordinary or tag"' failed.
#0 0x00007fa6e2d520b9 llvm::sys::PrintStackTrace(llvm::raw_ostream&) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/lib/Support/Unix/Signals.inc:398:11
#1 0x00007fa6e2d52269 PrintStackTraceSignalHandler(void*) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/lib/Support/Unix/Signals.inc:462:1
#2 0x00007fa6e2d508c3 llvm::sys::RunSignalHandlers() /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/lib/Support/Signals.cpp:0:5
#3 0x00007fa6e2d525c4 SignalHandler(int) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/lib/Support/Unix/Signals.inc:252:1
#4 0x00007fa6e1fc1390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
#5 0x00007fa6df3d4428 gsignal /build/glibc-Cl5G7W/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
#6 0x00007fa6df3d602a abort /build/glibc-Cl5G7W/glibc-2.23/stdlib/abort.c:91:0
#7 0x00007fa6df3ccbd7 __assert_fail_base /build/glibc-Cl5G7W/glibc-2.23/assert/assert.c:92:0
#8 0x00007fa6df3ccc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
#9 0x00007fa6dbaf23d6 clang::Decl::setObjectOfFriendDecl(bool) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/tools/clang/include/clang/AST/DeclBase.h:1042:18
#10 0x00007fa6dbad4eb6 clang::ASTNodeImporter::VisitFriendDecl(clang::FriendDecl*) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/tools/clang/lib/AST/ASTImporter.cpp:0:18
#11 0x00007fa6dbafe39c clang::declvisitor::Base<clang::declvisitor::make_ptr, clang::ASTNodeImporter, clang::Decl*>::Visit(clang::Decl*) /home/egbomrt/WORK/llvm/build/debug/tools/clang/include/clang/AST/DeclNodes.inc:71:1
#12 0x00007fa6dbac694a clang::ASTImporter::Import(clang::Decl*) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/tools/clang/lib/AST/ASTImporter.cpp:6493:9
#13 0x00007fa6dbacac57 clang::ASTNodeImporter::ImportDeclContext(clang::DeclContext*, bool, clang::DeclContext*) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/tools/clang/lib/AST/ASTImporter.cpp:1033:38
#14 0x00007fa6dbaca6a0 clang::ASTNodeImporter::ImportDefinition(clang::RecordDecl*, clang::RecordDecl*, clang::ASTNodeImporter::ImportDefinitionKind) /home/egbomrt/WORK/llvm/build/debug/../../git/llvm/tools/clang/lib/AST/ASTImporter.cpp:1173:3
``` 