### PR TITLE
Fix import of FriendDecl

### DIFF
--- a/include/clang/AST/DeclBase.h
+++ b/include/clang/AST/DeclBase.h
@@ -316,6 +316,7 @@ protected:
   friend class ASTDeclWriter;
   friend class ASTDeclReader;
   friend class ASTReader;
+  friend class ASTImporter;
   friend class LinkageComputer;
 
   template<typename decl_type> friend class Redeclarable;

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2747,11 +2747,8 @@ Decl *ASTNodeImporter::VisitFriendDecl(FriendDecl *D) {
   FriendDecl::FriendUnion ToFU;
   if (NamedDecl *FriendD = D->getFriendDecl()) {
     auto ToFriendD = cast_or_null<NamedDecl>(Importer.Import(FriendD));
-    if (ToFriendD && FriendD->getFriendObjectKind())
-      ToFriendD->setObjectOfFriendDecl();
-     ToFU = ToFriendD;
-  }
-  else
+    ToFU = ToFriendD;
+  } else
     ToFU = Importer.Import(D->getFriendType());
   if (!ToFU)
     return nullptr;
@@ -6734,7 +6731,8 @@ Decl *ASTImporter::Import(Decl *FromD) {
       }
     }
   }
-  
+
+  ToD->IdentifierNamespace = FromD->IdentifierNamespace;
   return ToD;
 }
 


### PR DESCRIPTION
Fixes #262 

The crux of the problem was that during import we did not set up the `IdentifierNamespace` of the `Decl`s. This caused that the imported `ToFriendD` had wrong IDNS value, which in turn caused the assertion in `setObjectOfFriendDecl()`.