### PR TITLE
Add const_cast to AST importer

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -6621,8 +6621,12 @@ Expr *ASTNodeImporter::VisitCXXNamedCastExpr(CXXNamedCastExpr *E) {
     return CXXReinterpretCastExpr::Create(
         Importer.getToContext(), ToType, VK, CK, ToOp, &BasePath, 
         ToWritten, ToOperatorLoc, ToRParenLoc, ToAngleBrackets);
+  } else if (isa<CXXConstCastExpr>(E)) {
+    return CXXConstCastExpr::Create(
+        Importer.getToContext(), ToType, VK, ToOp,
+        ToWritten, ToOperatorLoc, ToRParenLoc, ToAngleBrackets);
   } else {
-    return nullptr;
+    llvm_unreachable("Unknown cast type");
   }
 }
 

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -888,6 +888,39 @@ TEST(ImportExpr, CXXOperatorCallExpr) {
                                  has(cxxOperatorCallExpr()))))))))));
 }
 
+TEST(ImportExpr, CXXNamedCastExpr) {
+  MatchVerifier<Decl> Verifier;
+  EXPECT_TRUE(testImport("void declToImport() {"
+                         "  const_cast<char*>(\"hello\");"
+                         "}",
+                         Lang_CXX, "", Lang_CXX, Verifier,
+                         functionDecl(hasBody(compoundStmt(has(
+                             cxxConstCastExpr()))))));
+  EXPECT_TRUE(testImport("void declToImport() {"
+                         "  double d;"
+                         "  reinterpret_cast<int*>(&d);"
+                         "}",
+                         Lang_CXX, "", Lang_CXX, Verifier,
+                         functionDecl(hasBody(compoundStmt(has(
+                             cxxReinterpretCastExpr()))))));
+  EXPECT_TRUE(testImport("struct A {virtual ~A() {} };"
+                         "struct B : A {};"
+                         "void declToImport() {"
+                         "  dynamic_cast<B*>(new A);"
+                         "}",
+                         Lang_CXX, "", Lang_CXX, Verifier,
+                         functionDecl(hasBody(compoundStmt(has(
+                             cxxDynamicCastExpr()))))));
+  EXPECT_TRUE(testImport("struct A {virtual ~A() {} };"
+                         "struct B : A {};"
+                         "void declToImport() {"
+                         "  static_cast<B*>(new A);"
+                         "}",
+                         Lang_CXX, "", Lang_CXX, Verifier,
+                         functionDecl(hasBody(compoundStmt(has(
+                             cxxStaticCastExpr()))))));
+}
+
 TEST(ImportExpr, ImportUnresolvedLookupExpr) {
   MatchVerifier<Decl> Verifier;
   testImport("template<typename T> int foo();"


### PR DESCRIPTION
The const_cast was not covered by the AST importer.
Fixes #273