### PR TITLE
ASTImporter fix for recursive import of function

### DIFF
--- a/test/ASTMerge/class-template/Inputs/class-template3.cpp
+++ b/test/ASTMerge/class-template/Inputs/class-template3.cpp
@@ -1,0 +1,12 @@
+template <typename T>
+struct Y {};
+
+void f1(int, Y<int> &y) {}
+
+template <>
+struct Y<int> {
+  void f2() {
+    Y<int> a;
+    f1(0, a);
+  }
+};

--- a/test/ASTMerge/class-template/test.cpp
+++ b/test/ASTMerge/class-template/test.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -std=c++1z -emit-pch -o %t.1.ast %S/Inputs/class-template1.cpp
 // RUN: %clang_cc1 -std=c++1z -emit-pch -o %t.2.ast %S/Inputs/class-template2.cpp
-// RUN: %clang_cc1 -std=c++1z  -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -std=c++1z -emit-pch -o %t.3.ast %S/Inputs/class-template3.cpp
+// RUN: %clang_cc1 -std=c++1z  -ast-merge %t.1.ast -ast-merge %t.2.ast -ast-merge %t.3.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 static_assert(sizeof(X0<char>().getValue(1)) == sizeof(char));
 static_assert(sizeof(X0<int>().getValue(1)) == sizeof(int));


### PR DESCRIPTION
In some circumstances it is possible that a FunctionDecl is
imported duplicatedly during ASTNodeImporter::VisitFunctionDecl.
Checks are added to prevent overwrite of existing imported
FunctionDecl. New assertions are added to check for this
problem too. VisitStaticAssertDecl was updated with same check
because it was discovered that the problem happens here too.

This is probably a quick fix for the problem (does not solve the root cause).