### PR TITLE
Don't collect functions from non-compiling files

### DIFF
--- a/tools/clang-func-mapping/ClangFnMapGen.cpp
+++ b/tools/clang-func-mapping/ClangFnMapGen.cpp
@@ -46,7 +46,8 @@ public:
   }
 
   virtual void HandleTranslationUnit(ASTContext &Ctx) {
-    handleDecl(Ctx.getTranslationUnitDecl());
+    if (!Ctx.getDiagnostics().hasErrorOccurred())
+      handleDecl(Ctx.getTranslationUnitDecl());
   }
 
 private:
@@ -121,6 +122,5 @@ int main(int argc, const char **argv) {
 
   ClangTool Tool(OptionsParser.getCompilations(),
                  OptionsParser.getSourcePathList());
-  Tool.run(newFrontendActionFactory<MapFunctionNamesAction>().get());
-  return 0;
+  return Tool.run(newFrontendActionFactory<MapFunctionNamesAction>().get());
 }


### PR DESCRIPTION
The function collector shouldn't collect function names from files which
don't compile because this causes further errors in CTU analysis. Namely
the AST dump files can't be created because of the compilation error,
but the external function map file contains symbols which should be in
these. The error occurs when the AST importer tries to import these
function definitions from the non-existing AST dump file.

Fix