### PR TITLE
Builtin VA list is not imported anymore but taken from the destinatio…

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -139,6 +139,10 @@ namespace clang {
     /// NULL.
     Decl *GetAlreadyImportedOrNull(Decl *FromD);
 
+    /// \brief Return the declaration of the built-in type "__va_list_tag" from
+    /// the ASTContext instead of importing it.
+    Decl *GetVAListTag(Decl *FromD);
+
     /// \brief Import the given declaration context from the "from"
     /// AST context into the "to" AST context.
     ///

--- a/test/Analysis/Inputs/externalFnMap_va_list.txt
+++ b/test/Analysis/Inputs/externalFnMap_va_list.txt
@@ -1,0 +1,2 @@
+c:@F@first xtu-va_list-first.c.ast
+c:@F@second# xtu-va_list-second.cpp.ast

--- a/test/Analysis/Inputs/xtu-va_list-first.c
+++ b/test/Analysis/Inputs/xtu-va_list-first.c
@@ -1,0 +1,4 @@
+void first(int n, ...) {
+  __builtin_va_list ap;
+  __builtin_va_start(ap, n);
+}

--- a/test/Analysis/Inputs/xtu-va_list-second.cpp
+++ b/test/Analysis/Inputs/xtu-va_list-second.cpp
@@ -1,0 +1,3 @@
+void second() {
+  __builtin_va_list ap;
+}

--- a/test/Analysis/xtu-va_list.cpp
+++ b/test/Analysis/xtu-va_list.cpp
@@ -1,0 +1,54 @@
+// RUN: mkdir -p %T/xtudir4
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple x86_64-pc-linux-gnu -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: %clang_cc1 -triple powerpc-montavista-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple powerpc-montavista-pc-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple powerpc-montavista-pc-linux-gnu -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: %clang_cc1 -triple powerpc64-montavista-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple powerpc64-montavista-pc-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple powerpc64-montavista-pc-linux-gnu -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: %clang_cc1 -triple arm64-linux-android -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple arm64-linux-android -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple arm64-linux-android -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple le32-unknown-nacl -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: %clang_cc1 -triple arm-linux-androideabi -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple arm-linux-androideabi -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple arm-linux-androideabi -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: mkdir -p %T/xtudir4
+// RUN: %clang_cc1 -triple systemz-unknown-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple systemz-unknown-linux-gnu -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple systemz-unknown-linux-gnu -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// RUN: mkdir -p %T/xtudir4
+// RUN: %clang_cc1 -triple lanai-unknown-unknown -emit-pch -o %T/xtudir4/xtu-va_list-first.c.ast %S/Inputs/xtu-va_list-first.c
+// RUN: %clang_cc1 -triple lanai-unknown-unknown -emit-pch -o %T/xtudir4/xtu-va_list-second.cpp.ast %S/Inputs/xtu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/xtudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple lanai-unknown-unknown -analyzer-checker=core -analyzer-config xtu-dir=%T/xtudir4 -analyzer-config use-usr=true -analyzer-config reanalyze-xtu-visited=true -verify %s
+
+// expected-no-diagnostics
+
+extern "C" {
+void first(int, ...);
+}
+void second();
+
+void third() {
+  first(1, 2);
+  second();
+}

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -1566,5 +1566,18 @@ TEST_F(ImportFunctions,
   EXPECT_EQ(DefinitionD->getPreviousDecl(), ProtoD);
 }
 
+TEST_F(Fixture, OmitVAListTag) {
+  Decl *From, *To;
+  std::tie(From, To) =
+      getImportedDecl("void declToImport(int n, ...) {"
+                      "  __builtin_va_list __args;"
+                      "  __builtin_va_start(__args, n);"
+                      "}",
+                      Lang_C, "", Lang_C);
+  auto Pattern = translationUnitDecl(has(recordDecl(hasName("__va_list_tag"))));
+  EXPECT_FALSE(
+      MatchVerifier<Decl>{}.match(To->getTranslationUnitDecl(), Pattern));
+}
+
 } // end namespace ast_matchers
 } // end namespace clang


### PR DESCRIPTION
Solves issue #278 by taking __builtin_va_list and __va_list_tag from the destination AST Context instead of importing it.