### PR TITLE
fix for assertion getCheckName '!CheckName.empty()'

### DIFF
--- a/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -276,6 +276,9 @@ ProgramStateRef CStringChecker::CheckLocation(CheckerContext &C,
                                              ProgramStateRef state,
                                              const Expr *S, SVal l,
                                              const char *warningMsg) const {
+  if (!Filter.CheckCStringOutOfBounds)
+    return state;
+
   // If a previous check has failed, propagate the failure.
   if (!state)
     return nullptr;


### PR DESCRIPTION
in CStringChecker.cpp:
If the CStringOutOfBounds check is disabled do not perform the check in `CheckLocation` (and do not use the in this case empty string).
