### PR TITLE
Revert "fix for assertion getCheckName '!CheckName.empty()'"

### DIFF
--- a/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -276,9 +276,6 @@ ProgramStateRef CStringChecker::CheckLocation(CheckerContext &C,
                                              ProgramStateRef state,
                                              const Expr *S, SVal l,
                                              const char *warningMsg) const {
-  if (!Filter.CheckCStringOutOfBounds)
-    return state;
-
   // If a previous check has failed, propagate the failure.
   if (!state)
     return nullptr;


### PR DESCRIPTION
Reverts Ericsson/clang#302
Solution at  https://reviews.llvm.org/rC323052 will be used instead.