### PR TITLE
ASTImporter::Imported - VisitFunctionTemplateDecl assertion fix

### DIFF
--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -920,8 +920,7 @@ TEST_F(Fixture, ImportOfTemplatedDeclOfClassTemplateDecl) {
   EXPECT_EQ(ToTemplated1, ToTemplated);
 }
 
-// Currently disabled, because lookup fails to find the existing templated decl.
-TEST_F(Fixture, DISABLED_ImportOfTemplatedDeclOfFunctionTemplateDecl) {
+TEST_F(Fixture, ImportOfTemplatedDeclOfFunctionTemplateDecl) {
   Decl *FromTU = getTuDecl("template<class X> void f(){}", Lang_CXX);
   auto From = FirstDeclMatcher<FunctionTemplateDecl>().match(
       FromTU, functionTemplateDecl());


### PR DESCRIPTION
Fix for assertion
"Try to import an already imported Decl"
that occurs through calling
ASTNodeImporter::VisitFunctionTemplateDecl.

This fixes #311.