### PR TITLE
Fix more bogus ODR warning errors.

### DIFF
--- a/unittests/AST/DeclMatcher.h
+++ b/unittests/AST/DeclMatcher.h
@@ -52,7 +52,7 @@ class DeclCounter : public MatchFinder::MatchCallback {
       }
   }
 public:
-  // Returns the first/last matched node under the tree rooted in `D`.
+  // Returns the number of matched nodes under the tree rooted in `D`.
   template <typename MatcherType>
   unsigned match(const Decl *D, const MatcherType &AMatcher) {
     MatchFinder Finder;


### PR DESCRIPTION
PrevDecl was not set for ClassTemplateSpecializationDecl. This would mess up the canonical decl for the imported declaration and mislead the structural equivalence checker code.

Moreover, we need to set the PrevDecl of a CXXRecordDecl in the Create static method, not afterwards. This ensures that the TypeForDecl field is initialized correctly and we do not create a new type each time we import a declaration for an already existing one.
