### PR TITLE
ASTImporter::Imported - VisitClassTemplateDecl assertion fix

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2023,6 +2023,13 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
           Found = Tag->getDecl();
       }
       
+      if (D->getDescribedTemplate()) {
+        if (ClassTemplateDecl *Template = dyn_cast<ClassTemplateDecl>(Found))
+          Found = Template->getTemplatedDecl();
+        else
+          continue;
+      }
+      
       if (RecordDecl *FoundRecord = dyn_cast<RecordDecl>(Found)) {
         if (!SearchName) {
           // If both unnamed structs/unions are in a record context, make sure


### PR DESCRIPTION
Fix for assertion
"Try to import an already imported Decl"
that occurs through calling
ASTNodeImporter::VisitClassTemplateDecl.

Fix for #312 .