### PR TITLE
Revert to not support proto of recursive function

### DIFF
--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -1658,7 +1658,7 @@ TEST_F(ImportFunctions,
   EXPECT_TRUE(ToFD->doesThisDeclarationHaveABody());
 }
 
-TEST_F(ImportFunctions, ImportPrototypeOfRecursiveFunction) {
+TEST_F(ImportFunctions, DISABLED_ImportPrototypeOfRecursiveFunction) {
   Decl *FromTU = getTuDecl("void f(); void f() { f(); }", Lang_CXX);
   auto Pattern = functionDecl(hasName("f"));
   FunctionDecl *PrototypeFD =
@@ -1784,7 +1784,7 @@ TEST_F(ImportFunctions,
 }
 
 TEST_F(ImportFunctions,
-       ImportPrototypeThenProtoAndDefinition) {
+       DISABLED_ImportPrototypeThenProtoAndDefinition) {
   auto Pattern = functionDecl(hasName("f"));
 
   {


### PR DESCRIPTION
Temporarily disable the fix of importing the prototype of recursive functions #313 . This fix causes serious degradation in Xerces. We go on now with possible multiple definitions (violating ODR) until we came up with the proper long term solution. That solution will probably solve #327 and #282 as well.