### PR TITLE
Import the whole FunctionDecl chain

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 namespace clang {
+
   class ASTContext;
   class CXXCtorInitializer;
   class CXXBaseSpecifier;
@@ -34,7 +35,16 @@ namespace clang {
   class NestedNameSpecifier;
   class Stmt;
   class TypeSourceInfo;
-  
+
+  // \brief Returns with a list of declarations started from the canonical decl
+  // then followed by subsequent decls in the translation unit.
+  // This gives a canonical list for each entry in the redecl chain.
+  // `Decl::redecls()` gives a list of decls which always start from the
+  // previous decl and the next item is actually the previous item in the order
+  // of source locations.  Thus, `Decl::redecls()` gives different lists for
+  // the different entries in a given redecl chain.
+  llvm::SmallVector<Decl*, 2> getCanonicalForwardRedeclChain(Decl* D);
+
   /// \brief Imports selected nodes from one AST context into another context,
   /// merging AST nodes where appropriate.
   class ASTImporter {

--- a/test/ASTMerge/class/test.cpp
+++ b/test/ASTMerge/class/test.cpp
@@ -13,12 +13,12 @@
 // CHECK: class1.cpp:19:3: note: enumerator 'b' with value 1 here
 // CHECK: class2.cpp:12:3: note: enumerator 'a' with value 0 here
 
-// CHECK: class1.cpp:36:8: warning: type 'F2' has incompatible definitions in different translation units
-// CHECK: class1.cpp:39:3: note: friend declared here
-// CHECK: class2.cpp:30:8: note: no corresponding friend here
-
 // CHECK: class1.cpp:43:8: warning: type 'F3' has incompatible definitions in different translation units
 // CHECK: class1.cpp:46:3: note: friend declared here
 // CHECK: class2.cpp:36:8: note: no corresponding friend here
+
+// CHECK: class1.cpp:36:8: warning: type 'F2' has incompatible definitions in different translation units
+// CHECK: class1.cpp:39:3: note: friend declared here
+// CHECK: class2.cpp:30:8: note: no corresponding friend here
 
 // CHECK: 4 warnings generated.


### PR DESCRIPTION
With this PR when any Decl of a redeclaration chain is imported then we bring in the whole declaration chain.
The chain is imported as it is in the "from" tu, the order of the redeclarations are kept.
I also changed the lookup logic in order to find friends, but first making them visible in their declaration context.
We may have long redeclaration chains if all TU contains the same prototype, therefore I made some measurements on Xerces to see the scale of degradation.
Also, as further work we could squash redundant prototypes, but first let's see if functionality is working properly; then should we optimize.

Regression results on Xerces:

Baseline (*) with all asserts:
- successfully analyzed: 15
- "try to import already imported" assert: 291
- "should have body" assert: 42

Baseline (*) with disabled "try to import already imported" assert:
- successfully analyzed: 292
- "should have body" assert: 52
- "method is not virtual" assert: 4
- time: 1562s

This PR with all asserts:
- successfully analyzed: 15
- "try to import already imported" assert: 291
- "should have body" assert: 42

This PR with disabled "try to import already imported" assert:
- successfully analyzed: 296
- "should have body" assert: 52
- time: 1546s

As a summary, I did not recognize any regression in time. Also, "method is not virtual" assertions are corrected.

(*) I used the branch of #328, which reverts the problematic fix of importing prototype of recursive function.
