### PR TITLE
Fix for ASTImporter getInjectedClassNameType assertion

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2180,7 +2180,29 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         if (!ToDescribed)
           return nullptr;
         D2CXX->setDescribedClassTemplate(ToDescribed);
-
+        if (!DCXX->isInjectedClassName() && D->isCompleteDefinition()) {
+          // In a record describing a template the type should be a
+          // InjectedClassNameType (see Sema::CheckClassTemplate). Update the
+          // previously set type to the correct value here (ToDescribed is not
+          // available at record create).
+          // FIXME: The previous type is cleared but not removed from
+          // ASTContext's internal storage.
+          D2CXX->setTypeForDecl(nullptr);
+          Importer.getToContext().getInjectedClassNameType(D2CXX,
+              ToDescribed->getInjectedClassNameSpecialization());
+          // Find the injected class name itself and update the type too.
+          CXXRecordDecl *Injected = [&] {
+            for (NamedDecl *Found : D2CXX->noload_lookup(Name)) {
+              auto *Record = dyn_cast<CXXRecordDecl>(Found);
+              if (Record && Record->isInjectedClassName()) {
+                return Record;
+              }
+            }
+            assert(false && "No injected-class-name found!");
+          }();
+          Injected->setTypeForDecl(nullptr);
+          Importer.getToContext().getTypeDeclType(Injected, D2CXX);
+        }
       } else if (MemberSpecializationInfo *MemberInfo =
                    DCXX->getMemberSpecializationInfo()) {
         TemplateSpecializationKind SK =

--- a/test/ASTMerge/injected-class-name-decl/Inputs/inject1.cpp
+++ b/test/ASTMerge/injected-class-name-decl/Inputs/inject1.cpp
@@ -1,0 +1,1 @@
+template<class X> class C{static X x;};

--- a/test/ASTMerge/injected-class-name-decl/Inputs/inject2.cpp
+++ b/test/ASTMerge/injected-class-name-decl/Inputs/inject2.cpp
@@ -1,0 +1,1 @@
+template<class X> X C<X>::x;

--- a/test/ASTMerge/injected-class-name-decl/test.cpp
+++ b/test/ASTMerge/injected-class-name-decl/test.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -std=c++1z -emit-pch -o %t.ast %S/Inputs/inject1.cpp
+// RUN: %clang_cc1 -std=c++1z -emit-obj -o /dev/null -ast-merge %t.ast %S/Inputs/inject2.cpp
+// expected-no-diagnostics


### PR DESCRIPTION
After importing specific code a following assertion could happen.
The reason is that the templated CXXRecordDecl has not a InjectedClassNameType
associated with it.
Now the InjectedClassNameType is set at importing a CXXRecordDecl that is
contained within a template.