### PR TITLE
Refactor Decl creation

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -311,8 +311,10 @@ namespace clang {
     ///
     /// Subclasses can override this function to observe all of the \c From ->
     /// \c To declaration mappings as they are imported.
-    virtual Decl *Imported(Decl *From, Decl *To);
-      
+    virtual Decl *NotifyWhenImported(Decl *From, Decl *To) { return To; }
+
+    Decl *Imported(Decl *From, Decl *To);
+
     /// \brief Called by StructuralEquivalenceContext.  If a RecordDecl is
     /// being compared to another RecordDecl as part of import, completing the
     /// other RecordDecl may trigger importation of the first RecordDecl. This

--- a/include/clang/AST/DeclBase.h
+++ b/include/clang/AST/DeclBase.h
@@ -316,7 +316,7 @@ protected:
   friend class ASTDeclWriter;
   friend class ASTDeclReader;
   friend class ASTReader;
-  friend class ASTImporter;
+  friend class ASTNodeImporter;
   friend class LinkageComputer;
 
   template<typename decl_type> friend class Redeclarable;

--- a/include/clang/Basic/DiagnosticASTKinds.td
+++ b/include/clang/Basic/DiagnosticASTKinds.td
@@ -289,4 +289,6 @@ def err_odr_non_type_parameter_type_inconsistent : Warning<
 def err_unsupported_ast_node: Warning<"cannot import unsupported AST node %0">;
 def warn_ast_importer_missing_decl_in_decl_context : Warning<
   "missing %0Decl in imported DeclContext <%1:%2:%3>">;
+def warn_ast_importer_leaking_node : Warning<
+  "leaking %0Decl during import of %1">;
 }

--- a/include/clang/Basic/DiagnosticIDs.h
+++ b/include/clang/Basic/DiagnosticIDs.h
@@ -35,7 +35,7 @@ namespace clang {
       DIAG_START_LEX           = DIAG_START_SERIALIZATION   +  120,
       DIAG_START_PARSE         = DIAG_START_LEX             +  400,
       DIAG_START_AST           = DIAG_START_PARSE           +  500,
-      DIAG_START_COMMENT       = DIAG_START_AST             +  110,
+      DIAG_START_COMMENT       = DIAG_START_AST             +  200,
       DIAG_START_SEMA          = DIAG_START_COMMENT         +  100,
       DIAG_START_ANALYSIS      = DIAG_START_SEMA            + 3500,
       DIAG_UPPER_LIMIT         = DIAG_START_ANALYSIS        +  100

--- a/lib/AST/ExternalASTMerger.cpp
+++ b/lib/AST/ExternalASTMerger.cpp
@@ -39,14 +39,14 @@ public:
                   ASTContext &FromContext, FileManager &FromFileManager)
       : ASTImporter(ToContext, ToFileManager, FromContext, FromFileManager,
                     /*MinimalImport=*/true) {}
-  Decl *Imported(Decl *From, Decl *To) override {
+  Decl *NotifyWhenImported(Decl *From, Decl *To) override {
     if (auto ToTag = dyn_cast<TagDecl>(To)) {
       ToTag->setHasExternalLexicalStorage();
       ToTag->setMustBuildLookupTable();
     } else if (auto ToNamespace = dyn_cast<NamespaceDecl>(To)) {
       ToNamespace->setHasExternalVisibleStorage();
     }
-    return ASTImporter::Imported(From, To);
+    return To;
   }
 };
 


### PR DESCRIPTION
* Moved all `::Create()` under an umbrella function template which immediately calls `Imported()` after the create.
* Removed some redundant `Imported()` calls.
* Refactored `Imported()` into 3 independent functions, each with its own clear responsibility.
  * Register into `ImportedDecls`. Now `Imported()` has only this responsibility.
  * Notify subclasses about an event of a Decl import. Now this is in a new function `NotifyWhenImported`.
  * Copy attributes, `isImplicit` and IDNS. Now this is in a new function `InitializeImportedDecl`.