### PR TITLE
Avoid segfault in assert on valid FD missing case

### DIFF
--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -199,10 +199,10 @@ CrossTranslationUnitContext::getCrossTUDefinition(const FunctionDecl *FD,
                                                   StringRef CrossTUDir,
                                                   StringRef IndexName,
                                                   bool DisplayCTUProgress) {
-  assert(!FD->hasBody() && "FD has a definition in current translation unit!");
+  assert(!FD || (!FD->hasBody() && "FD has a definition in current translation unit!"));
   ++NumGetCTUCalled;
-  const std::string LookupFnName = getLookupName(FD);
-  if (LookupFnName.empty())
+  const std::string LookupFnName = FD ? getLookupName(FD) : std::string();
+  if (!FD || LookupFnName.empty())
     return llvm::make_error<IndexError>(
         index_error_code::failed_to_generate_usr);
   llvm::Expected<ASTUnit *> ASTUnitOrError =


### PR DESCRIPTION
CTU fails on every compilation unit in bitcoin debug mode because one assert causes segmentation fault.

Function `RuntimeDefinition AnyFunctionCall::getRuntimeDefinition() const` at https://github.com/Ericsson/clang/blob/ctu-clang6/lib/StaticAnalyzer/Core/CallEvent.cpp#L358 calls `getCrossTUDefinition` at https://github.com/Ericsson/clang/blob/ctu-clang6/lib/StaticAnalyzer/Core/CallEvent.cpp#L389 but before that, `FD` can be nullptr.

If this is the case, `getCrossTUDefinition` segfaults at https://github.com/Ericsson/clang/blob/ctu-clang6/lib/CrossTU/CrossTranslationUnit.cpp#L202 and later also asserts at https://github.com/Ericsson/clang/blob/ctu-clang6/lib/CrossTU/CrossTranslationUnit.cpp#L170

I think the original intention of that assert was not signalling the nullptr as this case seems to be handled correctly in other parts of the code.