### PR TITLE
ASTImporterTest ImportRecordDeclInFuncParams related fixes

### DIFF
--- a/include/clang/Frontend/ASTUnit.h
+++ b/include/clang/Frontend/ASTUnit.h
@@ -401,6 +401,8 @@ public:
 
   bool isMainFileAST() const { return MainFileIsAST; }
 
+  void beginSourceFile();
+  
   bool isUnsafeToFree() const { return UnsafeToFree; }
   void setUnsafeToFree(bool Value) { UnsafeToFree = Value; }
 

--- a/lib/Frontend/ASTUnit.cpp
+++ b/lib/Frontend/ASTUnit.cpp
@@ -225,6 +225,12 @@ ASTUnit::~ASTUnit() {
     fprintf(stderr, "--- %u translation units\n", --ActiveASTUnitObjects);
 }
 
+void ASTUnit::beginSourceFile() {
+  assert(getDiagnostics().getClient() && PP && Ctx &&
+      "Bad context for source file");
+  getDiagnostics().getClient()->BeginSourceFile(Ctx->getLangOpts(),PP.get());
+}
+
 void ASTUnit::setPreprocessor(std::shared_ptr<Preprocessor> PP) {
   this->PP = std::move(PP);
 }

--- a/test/ASTMerge/struct/Inputs/struct3.c
+++ b/test/ASTMerge/struct/Inputs/struct3.c
@@ -1,0 +1,2 @@
+// struct definition in function parameter
+int f(struct data_t{int a;int b;} *d){ return 0; }

--- a/test/ASTMerge/struct/test.c
+++ b/test/ASTMerge/struct/test.c
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/struct1.c
 // RUN: %clang_cc1 -emit-pch -o %t.2.ast %S/Inputs/struct2.c
-// RUN: not %clang_cc1 -Werror=odr -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -emit-pch -o %t.3.ast %S/Inputs/struct3.c
+// RUN: not %clang_cc1 -Werror=odr -ast-merge %t.1.ast -ast-merge %t.2.ast -ast-merge %t.3.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: struct1.c:13:8: error: type 'struct S1' has incompatible definitions in different translation units
 // CHECK: struct1.c:15:7: note: field 'field2' has type 'int' here
@@ -52,4 +53,5 @@
 // CHECK: struct2.c:129:9: note: field 'S' has type 'struct (anonymous struct at [[PATH_TO_INPUTS]]/struct2.c:127:7)' here
 // CHECK: struct2.c:138:3: error: external variable 'x16' declared with incompatible types in different translation units ('struct DeepUnnamedError' vs. 'struct DeepUnnamedError')
 // CHECK: struct1.c:141:3: note: declared here with type 'struct DeepUnnamedError'
+// CHECK: struct3.c:2:14: warning: cannot import unsupported AST node Record
 // CHECK: 21 errors generated


### PR DESCRIPTION
Added a new lit test to test that this is not supported.
The warning message could not be printed out in ASTImporterTest,
this is corrected. The ImportRecordDeclInFuncParams test still fails
but does not crash.