### PR TITLE
Fix already imported assert in class templates

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -4392,8 +4392,13 @@ Decl *ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
                                         = dyn_cast<ClassTemplateDecl>(Found)) {
         if (IsStructuralMatch(D, FoundTemplate)) {
           // The class templates structurally match; call it the same template.
-          // FIXME: We may be filling in a forward declaration here. Handle
-          // this case!
+
+          // We found a forward declaration but the class to be imported has a
+          // definition.
+          if (D->isThisDeclarationADefinition() &&
+              !FoundTemplate->isThisDeclarationADefinition())
+            continue;
+
           Importer.MapImported(D->getTemplatedDecl(),
                                FoundTemplate->getTemplatedDecl());
           return Importer.MapImported(D, FoundTemplate);


### PR DESCRIPTION
There is an import path, where the templated `RecordDecl` of a `ClassTemplateDecl` with a definition gets imported before the `ClassTemplateDecl` itself.
In this case, lookup may find a forward declaration for the very same `ClassTemplateDecl`.
However, `IsStructuralMatch` falsely reports structurally equivalence in between the forward decl and the definition. This is because `IsStructuralMatch` does not check member functions, only data members! 
By having this false structural match the assert fires on the `MapImport` of the templated decl because we want to assign a forward decl to the definition which we had already imported.
Either we change `IsStructuralMatch` or we add an extra check for this case.
I chose the latter, because changing `IsStructuralMatch` would have much broader side effects.