### PR TITLE
improved structural equivalence checking

### DIFF
--- a/lib/AST/ASTStructuralEquivalence.cpp
+++ b/lib/AST/ASTStructuralEquivalence.cpp
@@ -416,8 +416,6 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
   case Type::FunctionProto: {
     const auto *Proto1 = cast<FunctionProtoType>(T1);
     const auto *Proto2 = cast<FunctionProtoType>(T2);
-    const auto *OrigProto1 = cast<FunctionProtoType>(OrigT1);
-    const auto *OrigProto2 = cast<FunctionProtoType>(OrigT2);
 
     if (Proto1->getNumParams() != Proto2->getNumParams())
       return false;
@@ -431,8 +429,13 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
     
     if (Proto1->getTypeQuals() != Proto2->getTypeQuals())
       return false;
-    
-    // Check exceptions: This information may get lost in canonical type.
+
+    // Check exceptions, this information is lost in canonical type.
+    const auto *OrigProto1 =
+        cast<FunctionProtoType>(OrigT1.getDesugaredType(Context.FromCtx));
+    const auto *OrigProto2 =
+        cast<FunctionProtoType>(OrigT2.getDesugaredType(Context.ToCtx));
+
     auto Spec1 = OrigProto1->getExceptionSpecType();
     auto Spec2 = OrigProto2->getExceptionSpecType();
     

--- a/lib/AST/ASTStructuralEquivalence.cpp
+++ b/lib/AST/ASTStructuralEquivalence.cpp
@@ -237,6 +237,9 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
   if (T1.isNull() || T2.isNull())
     return T1.isNull() && T2.isNull();
 
+  QualType OrigT1 = T1;
+  QualType OrigT2 = T2;
+
   if (!Context.StrictTypeSpelling) {
     // We aren't being strict about token-to-token equivalence of types,
     // so map down to the canonical type.
@@ -411,8 +414,11 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
   }
 
   case Type::FunctionProto: {
-    const FunctionProtoType *Proto1 = cast<FunctionProtoType>(T1);
-    const FunctionProtoType *Proto2 = cast<FunctionProtoType>(T2);
+    const auto *Proto1 = cast<FunctionProtoType>(T1);
+    const auto *Proto2 = cast<FunctionProtoType>(T2);
+    const auto *OrigProto1 = cast<FunctionProtoType>(OrigT1);
+    const auto *OrigProto2 = cast<FunctionProtoType>(OrigT2);
+
     if (Proto1->getNumParams() != Proto2->getNumParams())
       return false;
     for (unsigned I = 0, N = Proto1->getNumParams(); I != N; ++I) {
@@ -422,23 +428,34 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
     }
     if (Proto1->isVariadic() != Proto2->isVariadic())
       return false;
-    if (Proto1->getExceptionSpecType() != Proto2->getExceptionSpecType())
-      return false;
-    if (Proto1->getExceptionSpecType() == EST_Dynamic) {
-      if (Proto1->getNumExceptions() != Proto2->getNumExceptions())
-        return false;
-      for (unsigned I = 0, N = Proto1->getNumExceptions(); I != N; ++I) {
-        if (!IsStructurallyEquivalent(Context, Proto1->getExceptionType(I),
-                                      Proto2->getExceptionType(I)))
-          return false;
-      }
-    } else if (Proto1->getExceptionSpecType() == EST_ComputedNoexcept) {
-      if (!IsStructurallyEquivalent(Context, Proto1->getNoexceptExpr(),
-                                    Proto2->getNoexceptExpr()))
-        return false;
-    }
+    
     if (Proto1->getTypeQuals() != Proto2->getTypeQuals())
       return false;
+    
+    // Check exceptions: This information may get lost in canonical type.
+    auto Spec1 = OrigProto1->getExceptionSpecType();
+    auto Spec2 = OrigProto2->getExceptionSpecType();
+    
+    if (!isUnresolvedExceptionSpec(Spec1) &&
+        !isUnresolvedExceptionSpec(Spec2)) {
+      if (Spec1 != Spec2)
+        return false;
+      if (Spec1 == EST_Dynamic) {
+        if (OrigProto1->getNumExceptions() != OrigProto2->getNumExceptions())
+          return false;
+        for (unsigned I = 0, N = OrigProto1->getNumExceptions(); I != N; ++I) {
+          if (!IsStructurallyEquivalent(Context,
+                                        OrigProto1->getExceptionType(I),
+                                        OrigProto2->getExceptionType(I)))
+            return false;
+        }
+      } else if (Spec1 == EST_ComputedNoexcept) {
+        if (!IsStructurallyEquivalent(Context,
+                                      OrigProto1->getNoexceptExpr(),
+                                      OrigProto2->getNoexceptExpr()))
+          return false;
+      }
+    }
 
     // Fall through to check the bits common with FunctionNoProtoType.
     LLVM_FALLTHROUGH;
@@ -827,6 +844,75 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
       return false;
     }
   }
+
+  return true;
+}
+
+/// Determine structural equivalence of two methodss.
+static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
+                                     CXXMethodDecl *Method1,
+                                     CXXMethodDecl *Method2) {
+  if (Method1->isStatic() != Method2->isStatic())
+    return false;
+  if (Method1->isConst() != Method2->isConst())
+    return false;
+  if (Method1->isVolatile() != Method2->isVolatile())
+    return false;
+  if (Method1->isVirtual() != Method2->isVirtual())
+    return false;
+  if (Method1->isPure() != Method2->isPure())
+    return false;
+  if (Method1->isDefaulted() != Method2->isDefaulted())
+    return false;
+  if (Method1->isDeleted() != Method2->isDeleted())
+    return false;
+  // FIXME: Check for 'final'.
+
+  if (Method1->getRefQualifier() != Method2->getRefQualifier())
+    return false;
+
+  if (Method1->getAccess() != Method2->getAccess())
+    return false;
+
+  if (auto *Constructor1 = dyn_cast<CXXConstructorDecl>(Method1)) {
+    if (auto *Constructor2 = dyn_cast<CXXConstructorDecl>(Method2)) {
+      if (Constructor1->isExplicit() != Constructor2->isExplicit())
+        return false;
+    } else
+      return false;
+  }
+  
+  if (auto *Conversion1 = dyn_cast<CXXConversionDecl>(Method1)) {
+    if (auto *Conversion2 = dyn_cast<CXXConversionDecl>(Method2)) {
+      if (Conversion1->isExplicit() != Conversion2->isExplicit())
+        return false;
+      if (!IsStructurallyEquivalent(Context, Conversion1->getConversionType(),
+                                    Conversion2->getConversionType()))
+        return false;
+    } else
+      return false;
+  }
+  
+  if (Method1->isOverloadedOperator() && Method2->isOverloadedOperator()) {
+    if (Method1->getOverloadedOperator() != Method2->getOverloadedOperator())
+      return false;
+    const IdentifierInfo *Literal1 = Method1->getLiteralIdentifier();
+    const IdentifierInfo *Literal2 = Method2->getLiteralIdentifier();
+    if (!::IsStructurallyEquivalent(Literal1, Literal2))
+      return false;
+  }
+
+  // Check method names.
+  const IdentifierInfo *Name1 = Method1->getIdentifier();
+  const IdentifierInfo *Name2 = Method2->getIdentifier();
+  if (!::IsStructurallyEquivalent(Name1, Name2)) {
+    return false;
+    // TODO: add warning
+  }
+
+  if (!::IsStructurallyEquivalent(Context,
+                                  Method1->getType(), Method2->getType()))
+    return false;
 
   return true;
 }
@@ -1500,6 +1586,14 @@ bool StructuralEquivalenceContext::Finish() {
       if (TemplateTemplateParmDecl *TTP2 =
               dyn_cast<TemplateTemplateParmDecl>(D2)) {
         if (!::IsStructurallyEquivalent(*this, TTP1, TTP2))
+          Equivalent = false;
+      } else {
+        // Kind mismatch.
+        Equivalent = false;
+      }
+    } else if (auto *MD1 = dyn_cast<CXXMethodDecl>(D1)) {
+      if (auto *MD2 = dyn_cast<CXXMethodDecl>(D2)) {
+        if (!::IsStructurallyEquivalent(*this, MD1, MD2))
           Equivalent = false;
       } else {
         // Kind mismatch.

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2689,6 +2689,163 @@ TEST_P(ASTImporterTestBase, ImportDefinitionOfClassTemplateAfterFwdDecl) {
   }
 }
 
+TEST_P(ASTImporterTestBase, ImportOfDeclAfterFwdDecl) {
+  Decl *ToD1;
+  {
+    Decl *FromTU = getTuDecl(
+        R"(
+            struct A;
+            )",
+        Lang_CXX, "input0.cc");
+    auto *FromD = FirstDeclMatcher<CXXRecordDecl>().match(
+        FromTU, cxxRecordDecl(hasName("A")));
+
+    ToD1 = Import(FromD, Lang_CXX);
+  }
+
+  Decl *ToD2;
+  {
+    Decl *FromTU = getTuDecl(
+        R"(
+            struct A { int x; };
+            )",
+        Lang_CXX, "input1.cc");
+    auto *FromD = FirstDeclMatcher<CXXRecordDecl>().match(
+        FromTU, cxxRecordDecl(hasName("A")));
+
+    ToD2 = Import(FromD, Lang_CXX);
+  }
+  
+  EXPECT_NE(ToD1, ToD2);
+  EXPECT_EQ(ToD1, ToD2->getPreviousDecl());
+}
+
+TEST_P(ASTImporterTestBase, ImportOfEquivalentRecord) {
+  Decl *ToR1;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { };", Lang_CXX, "input0.cc");
+    auto *FromR = FirstDeclMatcher<CXXRecordDecl>().match(
+        FromTU, cxxRecordDecl(hasName("A")));
+
+    ToR1 = Import(FromR, Lang_CXX);
+  }
+
+  Decl *ToR2;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { };", Lang_CXX, "input1.cc");
+    auto *FromR = FirstDeclMatcher<CXXRecordDecl>().match(
+        FromTU, cxxRecordDecl(hasName("A")));
+
+    ToR2 = Import(FromR, Lang_CXX);
+  }
+  
+  EXPECT_EQ(ToR1, ToR2);
+}
+
+TEST_P(ASTImporterTestBase, ImportOfNonEquivalentRecord) {
+  Decl *ToR1;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { int x; };", Lang_CXX, "input0.cc");
+    auto *FromR = FirstDeclMatcher<CXXRecordDecl>().match(
+        FromTU, cxxRecordDecl(hasName("A")));
+    ToR1 = Import(FromR, Lang_CXX);
+  }
+  Decl *ToR2;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { unsigned x; };", Lang_CXX, "input1.cc");
+    auto *FromR = FirstDeclMatcher<CXXRecordDecl>().match(
+        FromTU, cxxRecordDecl(hasName("A")));
+    ToR2 = Import(FromR, Lang_CXX);
+  }
+  EXPECT_NE(ToR1, ToR2);
+}
+
+TEST_P(ASTImporterTestBase, ImportOfEquivalentField) {
+  Decl *ToF1;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { int x; };", Lang_CXX, "input0.cc");
+    auto *FromF = FirstDeclMatcher<FieldDecl>().match(
+        FromTU, fieldDecl(hasName("x")));
+    ToF1 = Import(FromF, Lang_CXX);
+  }
+  Decl *ToF2;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { int x; };", Lang_CXX, "input1.cc");
+    auto *FromF = FirstDeclMatcher<FieldDecl>().match(
+        FromTU, fieldDecl(hasName("x")));
+    ToF2 = Import(FromF, Lang_CXX);
+  }
+  EXPECT_EQ(ToF1, ToF2);
+}
+
+TEST_P(ASTImporterTestBase, ImportOfNonEquivalentField) {
+  Decl *ToF1;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { int x; };", Lang_CXX, "input0.cc");
+    auto *FromF = FirstDeclMatcher<FieldDecl>().match(
+        FromTU, fieldDecl(hasName("x")));
+    ToF1 = Import(FromF, Lang_CXX);
+  }
+  Decl *ToF2;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { unsigned x; };", Lang_CXX, "input1.cc");
+    auto *FromF = FirstDeclMatcher<FieldDecl>().match(
+        FromTU, fieldDecl(hasName("x")));
+    ToF2 = Import(FromF, Lang_CXX);
+  }
+  EXPECT_NE(ToF1, ToF2);
+}
+
+TEST_P(ASTImporterTestBase, ImportOfEquivalentMethod) {
+  Decl *ToM1;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { void x(); }; void A::x() { }", Lang_CXX, "input0.cc");
+    auto *FromM = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("x"), isDefinition()));
+    ToM1 = Import(FromM, Lang_CXX);
+  }
+  Decl *ToM2;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { void x(); }; void A::x() { }", Lang_CXX, "input1.cc");
+    auto *FromM = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("x"), isDefinition()));
+    ToM2 = Import(FromM, Lang_CXX);
+  }
+  EXPECT_EQ(ToM1, ToM2);
+}
+
+TEST_P(ASTImporterTestBase, ImportOfNonEquivalentMethod) {
+  Decl *ToM1;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { void x(); }; void A::x() { }",
+        Lang_CXX, "input0.cc");
+    auto *FromM = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("x"), isDefinition()));
+    ToM1 = Import(FromM, Lang_CXX);
+  }
+  Decl *ToM2;
+  {
+    Decl *FromTU = getTuDecl(
+        "struct A { void x() const; }; void A::x() const { }",
+        Lang_CXX, "input1.cc");
+    auto *FromM = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("x"), isDefinition()));
+    ToM2 = Import(FromM, Lang_CXX);
+  }
+  EXPECT_NE(ToM1, ToM2);
+}
+
 INSTANTIATE_TEST_CASE_P(
     ParameterizedTests, ASTImporterTestBase,
     ::testing::Values(ArgVector(), ArgVector{"-fdelayed-template-parsing"}),);

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -320,6 +320,30 @@ TEST_F(StructuralEquivalenceFunctionTest, ParamPtr) {
   EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
 }
 
+TEST_F(StructuralEquivalenceFunctionTest, NameInParen) {
+  auto t = makeNamedDecls(
+      "void ((foo))();",
+      "void foo();",
+      Lang_CXX);
+  EXPECT_TRUE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, NameInParenWithExceptionSpec) {
+  auto t = makeNamedDecls(
+      "void (foo)() throw(int);",
+      "void (foo)() noexcept;",
+      Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, NameInParenWithConst) {
+  auto t = makeNamedDecls(
+      "struct A { void (foo)() const; };",
+      "struct A { void (foo)(); };",
+      Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
 struct StructuralEquivalenceCXXMethodTest : StructuralEquivalenceTest {
 };
 

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -17,13 +17,13 @@ struct StructuralEquivalenceTest : ::testing::Test {
   std::unique_ptr<ASTUnit> AST0, AST1;
   std::string Code0, Code1; // Buffers for SourceManager
 
-  // Get a pair of Decl pointers to the synthetised declarations from the given
-  // code snipets. By default we search for the unique Decl with name 'foo' in
-  // both snippets.
-  std::tuple<NamedDecl *, NamedDecl *>
-  makeNamedDecls(const std::string &SrcCode0, const std::string &SrcCode1,
-                 Language Lang, const char *const Identifier = "foo") {
-
+  // Get a pair of node pointers into the synthesized AST from the given code
+  // snippets. To determine the returned node, a separate matcher is specified
+  // for both snippets. The first matching node is returned.
+  template <typename NodeType, typename MatcherType>
+  std::tuple<NodeType *, NodeType *> makeDecls(
+      const std::string &SrcCode0, const std::string &SrcCode1, Language Lang,
+      const MatcherType &Matcher0, const MatcherType &Matcher1) {
     this->Code0 = SrcCode0;
     this->Code1 = SrcCode1;
     StringVector Args;
@@ -34,31 +34,34 @@ struct StructuralEquivalenceTest : ::testing::Test {
     AST0 = tooling::buildASTFromCodeWithArgs(Code0, Args, InputFileName);
     AST1 = tooling::buildASTFromCodeWithArgs(Code1, Args, InputFileName);
 
-    ASTContext &Ctx0 = AST0->getASTContext(), &Ctx1 = AST1->getASTContext();
+    NodeType *d0 = FirstDeclMatcher<NodeType>().match(
+        AST0->getASTContext().getTranslationUnitDecl(), Matcher0);
+    NodeType *d1 = FirstDeclMatcher<NodeType>().match(
+        AST1->getASTContext().getTranslationUnitDecl(), Matcher1);
 
-    auto getDecl = [](ASTContext &Ctx, const std::string &Name) -> NamedDecl * {
-      IdentifierInfo *ImportedII = &Ctx.Idents.get(Name);
-      assert(ImportedII && "Declaration with the identifier "
-                           "should be specified in test!");
-      DeclarationName ImportDeclName(ImportedII);
-      SmallVector<NamedDecl *, 4> FoundDecls;
-      Ctx.getTranslationUnitDecl()->localUncachedLookup(ImportDeclName,
-                                                        FoundDecls);
-
-      // We should find one Decl but one only
-      assert(FoundDecls.size() > 0);
-      assert(FoundDecls.size() < 2);
-
-      return FoundDecls[0];
-    };
-
-    NamedDecl *d0 = getDecl(Ctx0, Identifier);
-    NamedDecl *d1 = getDecl(Ctx1, Identifier);
-    assert(d0);
-    assert(d1);
     return std::make_tuple(d0, d1);
   }
+  
+  // Get a pair of node pointers into the synthesized AST from the given code
+  // snippets. The same matcher is used for both snippets.
+  template <typename NodeType, typename MatcherType>
+  std::tuple<NodeType *, NodeType *> makeDecls(
+      const std::string &SrcCode0, const std::string &SrcCode1, Language Lang,
+      const MatcherType &AMatcher) {
+    return makeDecls<NodeType, MatcherType>(
+          SrcCode0, SrcCode1, Lang, AMatcher, AMatcher);
+  }
 
+  // Get a pair of Decl pointers to the synthesized declarations from the given
+  // code snippets. We search for the first NamedDecl with given name in both
+  // snippets.
+  std::tuple<NamedDecl *, NamedDecl *> makeNamedDecls(
+      const std::string &SrcCode0, const std::string &SrcCode1,
+      Language Lang, const char *const Identifier = "foo") {
+    auto Matcher = namedDecl(hasName(Identifier));
+    return makeDecls<NamedDecl>(SrcCode0, SrcCode1, Lang, Matcher);
+  }
+  
   bool testStructuralMatch(NamedDecl *d0, NamedDecl *d1) {
     llvm::DenseSet<std::pair<Decl *, Decl *>> NonEquivalentDecls;
     StructuralEquivalenceContext Ctx(d0->getASTContext(), d1->getASTContext(),
@@ -109,35 +112,29 @@ TEST_F(StructuralEquivalenceTest, CharVsSignedCharInStruct) {
 }
 
 TEST_F(StructuralEquivalenceTest, IntVsSignedIntTemplateSpec) {
-  auto t = makeNamedDecls(
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
       R"(template <class T> struct foo; template<> struct foo<int>{};)",
       R"(template <class T> struct foo; template<> struct foo<signed int>{};)",
-      Lang_CXX);
-  ClassTemplateSpecializationDecl *Spec0 =
-      *cast<ClassTemplateDecl>(get<0>(t))->spec_begin();
-  ClassTemplateSpecializationDecl *Spec1 =
-      *cast<ClassTemplateDecl>(get<1>(t))->spec_begin();
-  ASSERT_TRUE(Spec0 != nullptr);
-  ASSERT_TRUE(Spec1 != nullptr);
+      Lang_CXX,
+      classTemplateSpecializationDecl());
+  auto Spec0 = get<0>(t);
+  auto Spec1 = get<1>(t);
   EXPECT_TRUE(testStructuralMatch(Spec0, Spec1));
 }
 
 TEST_F(StructuralEquivalenceTest, CharVsSignedCharTemplateSpec) {
-  auto t = makeNamedDecls(
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
       R"(template <class T> struct foo; template<> struct foo<char>{};)",
       R"(template <class T> struct foo; template<> struct foo<signed char>{};)",
-      Lang_CXX);
-  ClassTemplateSpecializationDecl *Spec0 =
-      *cast<ClassTemplateDecl>(get<0>(t))->spec_begin();
-  ClassTemplateSpecializationDecl *Spec1 =
-      *cast<ClassTemplateDecl>(get<1>(t))->spec_begin();
-  ASSERT_TRUE(Spec0 != nullptr);
-  ASSERT_TRUE(Spec1 != nullptr);
+      Lang_CXX,
+      classTemplateSpecializationDecl());
+  auto Spec0 = get<0>(t);
+  auto Spec1 = get<1>(t);
   EXPECT_FALSE(testStructuralMatch(Spec0, Spec1));
 }
 
 TEST_F(StructuralEquivalenceTest, CharVsSignedCharTemplateSpecWithInheritance) {
-  auto t = makeNamedDecls(
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
       R"(
 struct true_type{};
 template <class T> struct foo;
@@ -148,14 +145,9 @@ struct true_type{};
 template <class T> struct foo;
 template<> struct foo<signed char> : true_type {};
       )",
-      Lang_CXX);
-  ClassTemplateSpecializationDecl *Spec0 =
-      *cast<ClassTemplateDecl>(get<0>(t))->spec_begin();
-  ClassTemplateSpecializationDecl *Spec1 =
-      *cast<ClassTemplateDecl>(get<1>(t))->spec_begin();
-  ASSERT_TRUE(Spec0 != nullptr);
-  ASSERT_TRUE(Spec1 != nullptr);
-  EXPECT_FALSE(testStructuralMatch(Spec0, Spec1));
+      Lang_CXX,
+      classTemplateSpecializationDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
 }
 
 
@@ -206,6 +198,326 @@ TEST_F(StructuralEquivalenceTest, WrongOrderOfFieldsInClass) {
   RD->removeDecl(FD);
   RD->addDeclInternal(FD);
 
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+struct StructuralEquivalenceFunctionTest : StructuralEquivalenceTest {
+};
+
+TEST_F(StructuralEquivalenceFunctionTest, ParamConstWithRef) {
+  auto t = makeNamedDecls("void foo(int&);",
+                          "void foo(const int&);", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ParamConstSimple) {
+  auto t = makeNamedDecls("void foo(int);",
+                          "void foo(const int);", Lang_CXX);
+  EXPECT_TRUE(testStructuralMatch(get<0>(t), get<1>(t)));
+  // consider this OK
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, Throw) {
+  auto t = makeNamedDecls("void foo();",
+                          "void foo() throw();", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, Noexcept) {
+  auto t = makeNamedDecls("void foo();",
+                          "void foo() noexcept;", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ThrowVsNoexcept) {
+  auto t = makeNamedDecls("void foo() throw();",
+                          "void foo() noexcept;", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ThrowVsNoexceptFalse) {
+  auto t = makeNamedDecls("void foo() throw();",
+                          "void foo() noexcept(false);", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ThrowVsNoexceptTrue) {
+  auto t = makeNamedDecls("void foo() throw();",
+                          "void foo() noexcept(true);", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, DISABLED_NoexceptNonMatch) {
+  // The expression is not checked yet.
+  auto t = makeNamedDecls("void foo() noexcept(false);",
+                          "void foo() noexcept(true);", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, NoexceptMatch) {
+  auto t = makeNamedDecls("void foo() noexcept(false);",
+                          "void foo() noexcept(false);", Lang_CXX11);
+  EXPECT_TRUE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, NoexceptVsNoexceptFalse) {
+  auto t = makeNamedDecls("void foo() noexcept;",
+                          "void foo() noexcept(false);", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, NoexceptVsNoexceptTrue) {
+  auto t = makeNamedDecls("void foo() noexcept;",
+                          "void foo() noexcept(true);", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ReturnType) {
+  auto t = makeNamedDecls("char foo();",
+                          "int foo();", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ReturnConst) {
+  auto t = makeNamedDecls("char foo();",
+                          "const char foo();", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ReturnRef) {
+  auto t = makeNamedDecls("char &foo();",
+                          "char &&foo();", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ParamCount) {
+  auto t = makeNamedDecls("void foo(int);",
+                          "void foo(int, int);", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ParamType) {
+  auto t = makeNamedDecls("void foo(int);",
+                          "void foo(char);", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ParamName) {
+  auto t = makeNamedDecls("void foo(int a);",
+                          "void foo(int b);", Lang_CXX);
+  EXPECT_TRUE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, Variadic) {
+  auto t = makeNamedDecls("void foo(int x...);",
+                          "void foo(int x);", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceFunctionTest, ParamPtr) {
+  auto t = makeNamedDecls("void foo(int *);",
+                          "void foo(int);", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+struct StructuralEquivalenceCXXMethodTest : StructuralEquivalenceTest {
+};
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Virtual) {
+  auto t = makeDecls<CXXMethodDecl>(
+      "struct X { void foo(); };",
+      "struct X { virtual void foo(); };", Lang_CXX,
+      cxxMethodDecl(hasName("foo")));
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Pure) {
+  auto t = makeNamedDecls("struct X { virtual void foo(); };",
+                          "struct X { virtual void foo() = 0; };", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, DISABLED_Final) {
+  // The final-ness is not checked yet.
+  auto t = makeNamedDecls("struct X { virtual void foo(); };",
+                          "struct X { virtual void foo() final; };", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Const) {
+  auto t = makeNamedDecls("struct X { void foo(); };",
+                          "struct X { void foo() const; };", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Static) {
+  auto t = makeNamedDecls("struct X { void foo(); };",
+                          "struct X { static void foo(); };", Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Ref1) {
+  auto t = makeNamedDecls("struct X { void foo(); };",
+                          "struct X { void foo() &&; };", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Ref2) {
+  auto t = makeNamedDecls("struct X { void foo() &; };",
+                          "struct X { void foo() &&; };", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, AccessSpecifier) {
+  auto t = makeDecls<CXXMethodDecl>(
+      "struct X { public: void foo(); };",
+      "struct X { private: void foo(); };", Lang_CXX,
+      cxxMethodDecl(hasName("foo")));
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Delete) {
+  auto t = makeNamedDecls("struct X { void foo(); };",
+                          "struct X { void foo() = delete; };", Lang_CXX11);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Constructor) {
+  auto t = makeDecls<FunctionDecl>(
+      "void foo();", "struct foo { foo(); };", Lang_CXX,
+      functionDecl(), cxxConstructorDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, ConstructorParam) {
+  auto t = makeDecls<CXXConstructorDecl>("struct X { X(); };",
+                                         "struct X { X(int); };", Lang_CXX,
+                                         cxxConstructorDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, ConstructorExplicit) {
+  auto t = makeDecls<CXXConstructorDecl>("struct X { X(int); };",
+                                         "struct X { explicit X(int); };",
+                                         Lang_CXX11,
+                                         cxxConstructorDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, ConstructorDefault) {
+  auto t = makeDecls<CXXConstructorDecl>("struct X { X(); };",
+                                         "struct X { X() = default; };",
+                                         Lang_CXX11,
+                                         cxxConstructorDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Conversion) {
+  auto t = makeDecls<CXXConversionDecl>("struct X { operator bool(); };",
+                                        "struct X { operator char(); };",
+                                         Lang_CXX11,
+                                         cxxConversionDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, Operator) {
+  auto t = makeDecls<FunctionDecl>(
+      "struct X { int operator +(int); };",
+      "struct X { int operator -(int); };", Lang_CXX,
+      functionDecl(hasOverloadedOperatorName("+")),
+      functionDecl(hasOverloadedOperatorName("-")));
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, OutOfClass1) {
+  auto t = makeDecls<FunctionDecl>(
+      "struct X { virtual void f(); }; void X::f() { }",
+      "struct X { virtual void f() { }; };",
+      Lang_CXX,
+      functionDecl(allOf(hasName("f"), isDefinition())));
+  EXPECT_TRUE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceCXXMethodTest, OutOfClass2) {
+  auto t = makeDecls<FunctionDecl>(
+      "struct X { virtual void f(); }; void X::f() { }",
+      "struct X { void f(); }; void X::f() { }",
+      Lang_CXX,
+      functionDecl(allOf(hasName("f"), isDefinition())));
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+struct StructuralEquivalenceRecordTest : StructuralEquivalenceTest {
+};
+
+TEST_F(StructuralEquivalenceRecordTest, Name) {
+  auto t = makeDecls<CXXRecordDecl>(
+      "struct A{ };",
+      "struct B{ };",
+      Lang_CXX,
+      cxxRecordDecl());
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, Fields) {
+  auto t = makeNamedDecls(
+      "struct foo{ int x; };",
+      "struct foo{ char x; };",
+      Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, DISABLED_Methods) {
+  auto t = makeNamedDecls(
+      "struct foo{ int x(); };",
+      "struct foo{ char x(); };",
+      Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, Bases) {
+  auto t = makeNamedDecls(
+      "struct A{ }; struct foo: A { };",
+      "struct B{ }; struct foo: B { };",
+      Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, InheritanceVirtual) {
+  auto t = makeNamedDecls(
+      "struct A{ }; struct foo: A { };",
+      "struct A{ }; struct foo: virtual A { };",
+      Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, DISABLED_InheritanceType) {
+  // Access specifier in inheritance is not checked yet.
+  auto t = makeNamedDecls(
+      "struct A{ }; struct foo: public A { };",
+      "struct A{ }; struct foo: private A { };",
+      Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, Match) {
+  auto Code = R"(
+      struct A{ };
+      struct B{ };
+      struct foo: A, virtual B {
+        void x();
+        int a;
+      };
+      )";
+  auto t = makeNamedDecls(Code, Code, Lang_CXX);
+  EXPECT_TRUE(testStructuralMatch(get<0>(t), get<1>(t)));
+}
+
+TEST_F(StructuralEquivalenceTest, CompareSameDeclWithMultiple) {
+  auto t = makeNamedDecls(
+      "struct A{ }; struct B{ }; void foo(A a, A b);",
+      "struct A{ }; struct B{ }; void foo(A a, B b);",
+      Lang_CXX);
   EXPECT_FALSE(testStructuralMatch(get<0>(t), get<1>(t)));
 }
 


### PR DESCRIPTION
Added check for `CXXMethodDecl` (not complete: some template cases missing?).
Cleaned up check of FunctionTemplateDecl.
Added unit tests.

Diagnostic messages not added.