### PR TITLE
Fix structural equivalence poisonous cache problem by fixing the recursion

### DIFF
--- a/include/clang/AST/ASTStructuralEquivalence.h
+++ b/include/clang/AST/ASTStructuralEquivalence.h
@@ -36,11 +36,13 @@ struct StructuralEquivalenceContext {
   /// The set of "tentative" equivalences between two canonical
   /// declarations, mapping from a declaration in the first context to the
   /// declaration in the second context that we believe to be equivalent.
-  llvm::DenseMap<Decl *, Decl *> TentativeEquivalences;
+  //llvm::DenseMap<Decl *, Decl *> TentativeEquivalences;
 
   /// Queue of declarations in the first context whose equivalence
   /// with a declaration in the second context still needs to be verified.
-  std::deque<Decl *> DeclsToCheck;
+  std::deque<std::pair<Decl *, Decl *>> DeclsToCheck;
+
+  llvm::DenseSet<std::pair<Decl *, Decl *>> Marked;
 
   /// Declaration (from, to) pairs that are known not to be equivalent
   /// (which we have already complained about).
@@ -74,10 +76,10 @@ struct StructuralEquivalenceContext {
 
   /// Determine whether the two declarations are structurally
   /// equivalent.
-  bool IsStructurallyEquivalent(Decl *D1, Decl *D2);
+  bool IsEquivalent(Decl *D1, Decl *D2);
 
   /// Determine whether the two types are structurally equivalent.
-  bool IsStructurallyEquivalent(QualType T1, QualType T2);
+  bool IsEquivalent(QualType T1, QualType T2);
 
   /// Find the index of the given anonymous struct/union within its
   /// context.

--- a/include/clang/AST/ASTStructuralEquivalence.h
+++ b/include/clang/AST/ASTStructuralEquivalence.h
@@ -33,16 +33,12 @@ struct StructuralEquivalenceContext {
   /// AST contexts for which we are checking structural equivalence.
   ASTContext &FromCtx, &ToCtx;
 
-  /// The set of "tentative" equivalences between two canonical
-  /// declarations, mapping from a declaration in the first context to the
-  /// declaration in the second context that we believe to be equivalent.
-  //llvm::DenseMap<Decl *, Decl *> TentativeEquivalences;
-
-  /// Queue of declarations in the first context whose equivalence
-  /// with a declaration in the second context still needs to be verified.
+  /// Queue of declaration (from, to) pairs whose equivalence still needs to
+  /// be verified.
   std::deque<std::pair<Decl *, Decl *>> DeclsToCheck;
 
-  llvm::DenseSet<std::pair<Decl *, Decl *>> Marked;
+  /// Set of those pairs which we already had checked for equivalency.
+  llvm::DenseSet<std::pair<Decl *, Decl *>> Visited;
 
   /// Declaration (from, to) pairs that are known not to be equivalent
   /// (which we have already complained about).

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -1545,7 +1545,7 @@ bool ASTNodeImporter::IsStructuralMatch(RecordDecl *FromRecord,
                                    ToRecord->getASTContext(),
                                    Importer.getNonEquivalentDecls(),
                                    false, Complain);
-  return Ctx.IsStructurallyEquivalent(FromRecord, ToRecord);
+  return Ctx.IsEquivalent(FromRecord, ToRecord);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(VarDecl *FromVar, VarDecl *ToVar,
@@ -1553,7 +1553,7 @@ bool ASTNodeImporter::IsStructuralMatch(VarDecl *FromVar, VarDecl *ToVar,
   StructuralEquivalenceContext Ctx(
       Importer.getFromContext(), Importer.getToContext(),
       Importer.getNonEquivalentDecls(), false, Complain);
-  return Ctx.IsStructurallyEquivalent(FromVar, ToVar);
+  return Ctx.IsEquivalent(FromVar, ToVar);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(EnumDecl *FromEnum, EnumDecl *ToEnum,
@@ -1562,7 +1562,7 @@ bool ASTNodeImporter::IsStructuralMatch(EnumDecl *FromEnum, EnumDecl *ToEnum,
                                    Importer.getToContext(),
                                    Importer.getNonEquivalentDecls(),
                                    false, Complain);
-  return Ctx.IsStructurallyEquivalent(FromEnum, ToEnum);
+  return Ctx.IsEquivalent(FromEnum, ToEnum);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(FunctionTemplateDecl *From,
@@ -1571,14 +1571,14 @@ bool ASTNodeImporter::IsStructuralMatch(FunctionTemplateDecl *From,
                                    Importer.getToContext(),
                                    Importer.getNonEquivalentDecls(),
                                    false, false);
-  return Ctx.IsStructurallyEquivalent(From, To);
+  return Ctx.IsEquivalent(From, To);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(FunctionDecl *From, FunctionDecl *To) {
   StructuralEquivalenceContext Ctx(
       Importer.getFromContext(), Importer.getToContext(),
       Importer.getNonEquivalentDecls(), false, false);
-  return Ctx.IsStructurallyEquivalent(From, To);
+  return Ctx.IsEquivalent(From, To);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(EnumConstantDecl *FromEC,
@@ -1602,7 +1602,7 @@ bool ASTNodeImporter::IsStructuralMatch(ClassTemplateDecl *From,
   StructuralEquivalenceContext Ctx(Importer.getFromContext(),
                                    Importer.getToContext(),
                                    Importer.getNonEquivalentDecls());
-  return Ctx.IsStructurallyEquivalent(From, To);
+  return Ctx.IsEquivalent(From, To);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(VarTemplateDecl *From,
@@ -1610,7 +1610,7 @@ bool ASTNodeImporter::IsStructuralMatch(VarTemplateDecl *From,
   StructuralEquivalenceContext Ctx(Importer.getFromContext(),
                                    Importer.getToContext(),
                                    Importer.getNonEquivalentDecls());
-  return Ctx.IsStructurallyEquivalent(From, To);
+  return Ctx.IsEquivalent(From, To);
 }
 
 Decl *ASTNodeImporter::VisitDecl(Decl *D) {
@@ -2953,8 +2953,8 @@ Decl *ASTNodeImporter::VisitFriendDecl(FriendDecl *D) {
 
   while (ImportedFriend) {
     if (D->getFriendDecl() && ImportedFriend->getFriendDecl()) {
-      if (Context.IsStructurallyEquivalent(D->getFriendDecl(),
-                                           ImportedFriend->getFriendDecl()))
+      if (Context.IsEquivalent(D->getFriendDecl(),
+                               ImportedFriend->getFriendDecl()))
         return Importer.MapImported(D, ImportedFriend);
 
     } else if (D->getFriendType() && ImportedFriend->getFriendType()) {
@@ -7679,5 +7679,5 @@ bool ASTImporter::IsStructurallyEquivalent(QualType From, QualType To,
 
   StructuralEquivalenceContext Ctx(FromContext, ToContext, NonEquivalentDecls,
                                    false, Complain);
-  return Ctx.IsStructurallyEquivalent(From, To);
+  return Ctx.IsEquivalent(From, To);
 }

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -7415,7 +7415,7 @@ bool Sema::hasStructuralCompatLayout(Decl *D, Decl *Suggested) {
       D->getASTContext(), Suggested->getASTContext(), NonEquivalentDecls,
       false /*StrictTypeSpelling*/, true /*Complain*/,
       true /*ErrorOnTagTypeMismatch*/);
-  return Ctx.IsStructurallyEquivalent(D, Suggested);
+  return Ctx.IsEquivalent(D, Suggested);
 }
 
 /// \brief Determine whether there is any declaration of \p D that was ever a

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -63,7 +63,7 @@ struct StructuralEquivalenceTest : ::testing::Test {
     llvm::DenseSet<std::pair<Decl *, Decl *>> NonEquivalentDecls;
     StructuralEquivalenceContext Ctx(d0->getASTContext(), d1->getASTContext(),
                                      NonEquivalentDecls, false, false);
-    return Ctx.IsStructurallyEquivalent(d0, d1);
+    return Ctx.IsEquivalent(d0, d1);
   }
 };
 


### PR DESCRIPTION
During the equivalence check the current algorithm has some failures.
The equivalence check itself is a recursive algorithm, similar to ASTImporter.
With similar difficulties, e.g. when we check a function template then we will check the templated declaration; however, when we check the templated declaration then we have to check the described template.
The NonEquivalentDecls cache has the purpose to store those decl pairs which are not equal.
During a check we collect all the declarations which shall be compared in DeclsToCheck and in the auxiliary TentativeEquivalences.

One problem is that some implementation functions call into the member functions of ASTStructuralEquivalence, thus they can falsely alter the DeclsToCheck state (they add decls).
This results that some leaf declarations can be stated as inequivalent as a side effect of one inequivalent element in the DeclsToCheck list.
And since we store the non-equivalencies, any (otherwise independent) decls will be rendered as non-equivalent.
Solution: I tried to clearly separate the implementation functions (the static ones) and the public interface.
From now on, the implementation functions do not call any public member functions, only other implementation functions.

The other problem is that TentativeEquivalences plays two roles.
It is used to store the second half of the decls which we want to compare, plus it plays a role in closing the recursion.
For properly closing the recursion it should be emptied in the interface toplevel functions.
Also DeclsToCheck should be emptied too when a toplevel interface function is called.
Solution: I clearly separated these two responsibilities into a DFS visited/marked set and changed DeclsToCheck to contain (from, to) pairs.
Also the state is reset when toplevel interface functions are called.
