### PR TITLE
Import redecl chain of function template specializations

### DIFF
--- a/lib/AST/DeclBase.cpp
+++ b/lib/AST/DeclBase.cpp
@@ -1346,6 +1346,8 @@ bool DeclContext::decls_empty() const {
 }
 
 bool DeclContext::containsDecl(Decl *D) const {
+  if (hasExternalLexicalStorage())
+    LoadLexicalDeclsFromExternalStorage();
   return (D->getLexicalDeclContext() == this &&
           (D->NextInContextAndBits.getPointer() || D == LastDecl));
 }

--- a/test/Import/template-specialization/Inputs/T.cpp
+++ b/test/Import/template-specialization/Inputs/T.cpp
@@ -12,3 +12,7 @@ template <> struct A<bool> {
     int g;
   };
 };
+
+
+template <typename T> constexpr int f() { return 0; }
+template <> constexpr int f<int>() { return 4; }

--- a/test/Import/template-specialization/test.cpp
+++ b/test/Import/template-specialization/test.cpp
@@ -4,3 +4,6 @@ void expr() {
   A<bool>::B b2;
   b1.f + b2.g;
 }
+
+static_assert(f<char>() == 0, "");
+static_assert(f<int>() == 4, "");


### PR DESCRIPTION
In case of function template specializations, their `DeclContext` was not set up correctly.
Also, the redecl chain was not set up. This caused an error since #329 where we just simply removed the related tests. For upstreaming any redecl chain related change, we had to re enable those tests and implement the redecl chain for specializations too.