### PR TITLE
fix missing std-initializer-list test argument

### DIFF
--- a/test/ASTMerge/std-initializer-list/test.cpp
+++ b/test/ASTMerge/std-initializer-list/test.cpp
@@ -1,3 +1,3 @@
 // RUN: %clang++ -x c++-header -std=c++11 -o %t.1.ast %S/Inputs/il.cpp
-// RUN: %clang_cc1 -x c++ -ast-merge %t.1.ast -fsyntax-only %s 2>&1 | FileCheck --allow-empty %s
+// RUN: %clang_cc1 -x c++ -std=c++11 -ast-merge %t.1.ast -fsyntax-only %s 2>&1 | FileCheck --allow-empty %s
 // CHECK-NOT: unsupported AST node


### PR DESCRIPTION
-ast-merge clang call failed with fatal error: 'initializer_list' file
not found error