### PR TITLE
ASTImporter correct mapping of function definition to existing definition

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2607,9 +2607,11 @@ Decl *ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
           if (FoundFunction->hasExternalFormalLinkage() &&
               D->hasExternalFormalLinkage()) {
             if (IsStructuralMatch(D, FoundFunction)) {
+              const FunctionDecl *Definition = nullptr;
               if (D->doesThisDeclarationHaveABody() &&
-                  FoundFunction->hasBody())
-                return Importer.MapImported(D, FoundFunction);
+                  FoundFunction->hasBody(Definition))
+                return Importer.MapImported(
+                    D, const_cast<FunctionDecl *>(Definition));
               FoundByLookup = FoundFunction;
               break;
             }

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2529,6 +2529,27 @@ TEST_P(ImportFunctions,
             }).match(ToTU, functionDecl()));
 }
 
+TEST_P(ImportFunctions,
+       ImportOfDefinitionIsMappedToExistingDefinition) {
+  Decl *ToM1;
+  {
+    Decl *FromTU = getTuDecl(
+        "void x(); void x() { }; void x();", Lang_CXX, "input0.cc");
+    auto *FromM = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("x"), isDefinition()));
+    ToM1 = Import(FromM, Lang_CXX);
+  }
+  Decl *ToM2;
+  {
+    Decl *FromTU = getTuDecl(
+        "void x(); void x() { }; void x();", Lang_CXX, "input1.cc");
+    auto *FromM = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("x"), isDefinition()));
+    ToM2 = Import(FromM, Lang_CXX);
+  }
+  EXPECT_EQ(ToM1, ToM2);
+}
+
 struct ImportFriendFunctions : ImportFunctions {};
 
 TEST_P(ImportFriendFunctions, ImportFriendList) {


### PR DESCRIPTION
When importing a function definition over an existing definition of the same
function, the definition should be mapped to the existing definition.