### PR TITLE
[ASTImporter] Changed unsupported node handling

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -91,9 +91,9 @@ namespace clang {
     /// (which we have already complained about).
     NonEquivalentDeclSet NonEquivalentDecls;
 
-    /// This flag signs if the Importer encountered an unsupported node during
-    /// the last import process.
-    bool encounteredUnsupportedNode;
+    /// This flag signs if the Importer encountered an unsupported construct
+    /// during the last import process.
+    bool EncounteredUnsupportedConstruct;
 
   public:
     /// \brief Create a new AST importer.
@@ -327,11 +327,13 @@ namespace clang {
     bool IsStructurallyEquivalent(QualType From, QualType To,
                                   bool Complain = true);
 
-    void setEncounteredUnsupportedNode(bool B) {
-      encounteredUnsupportedNode = B;
+    void setEncounteredUnsupportedConstruct(bool B) {
+      EncounteredUnsupportedConstruct = B;
     }
 
-    bool hasEncounteredUnsupportedNode() { return encounteredUnsupportedNode; }
+    bool hasEncounteredUnsupportedConstruct() const {
+      return EncounteredUnsupportedConstruct;
+    }
   };
 }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -264,6 +264,7 @@ namespace clang {
     bool IsStructuralMatch(ClassTemplateDecl *From, ClassTemplateDecl *To);
     bool IsStructuralMatch(VarTemplateDecl *From, VarTemplateDecl *To);
     Decl *VisitDecl(Decl *D);
+    Decl *VisitImportDecl(ImportDecl *D);
     Decl *VisitEmptyDecl(EmptyDecl *D);
     Decl *VisitAccessSpecDecl(AccessSpecDecl *D);
     Decl *VisitStaticAssertDecl(StaticAssertDecl *D);
@@ -527,9 +528,7 @@ ASTNodeImporter::ImportFunctionTemplateWithTemplateArgsFromSpecialization(
 using namespace clang;
 
 QualType ASTNodeImporter::VisitType(const Type *T) {
-  Importer.FromDiag(SourceLocation(), diag::err_unsupported_ast_node)
-    << T->getTypeClassName();
-  Importer.setEncounteredUnsupportedNode(true);
+  assert(false && "Unsupported Type at import");
   return QualType();
 }
 
@@ -1117,7 +1116,7 @@ bool ASTNodeImporter::ImportDeclParts(NamedDecl *D, DeclContext *&DC,
       if (RT && RT->getDecl() == D) {
         Importer.FromDiag(D->getLocation(), diag::err_unsupported_ast_node)
             << D->getDeclKindName();
-        Importer.setEncounteredUnsupportedNode(true);
+        Importer.setEncounteredUnsupportedConstruct(true);
         return true;
       }
     }
@@ -1690,9 +1689,14 @@ bool ASTNodeImporter::IsStructuralMatch(VarTemplateDecl *From,
 }
 
 Decl *ASTNodeImporter::VisitDecl(Decl *D) {
+  assert(false && "Unsupported Decl at import");
+  return nullptr;
+}
+
+Decl *ASTNodeImporter::VisitImportDecl(ImportDecl *D) {
   Importer.FromDiag(D->getLocation(), diag::err_unsupported_ast_node)
-    << D->getDeclKindName();
-  Importer.setEncounteredUnsupportedNode(true);
+      << D->getDeclKindName();
+  Importer.setEncounteredUnsupportedConstruct(true);
   return nullptr;
 }
 
@@ -5024,9 +5028,7 @@ DeclGroupRef ASTNodeImporter::ImportDeclGroup(DeclGroupRef DG) {
 }
 
  Stmt *ASTNodeImporter::VisitStmt(Stmt *S) {
-   Importer.FromDiag(S->getLocStart(), diag::err_unsupported_ast_node)
-     << S->getStmtClassName();
-   Importer.setEncounteredUnsupportedNode(true);
+   assert(false && "Unsupported Stmt at import");
    return nullptr;
  }
 
@@ -5551,9 +5553,7 @@ Stmt *ASTNodeImporter::VisitObjCAutoreleasePoolStmt
 // Import Expressions
 //----------------------------------------------------------------------------
 Expr *ASTNodeImporter::VisitExpr(Expr *E) {
-  Importer.FromDiag(E->getLocStart(), diag::err_unsupported_ast_node)
-    << E->getStmtClassName();
-  Importer.setEncounteredUnsupportedNode(true);
+  assert(false && "Unsupported Expr at import");
   return nullptr;
 }
 
@@ -7088,7 +7088,7 @@ ASTImporter::ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
     : ToContext(ToContext), FromContext(FromContext),
       ToFileManager(ToFileManager), FromFileManager(FromFileManager),
       Minimal(MinimalImport), LastDiagFromFrom(false),
-      encounteredUnsupportedNode(false) {
+      EncounteredUnsupportedConstruct(false) {
   ImportedDecls[FromContext.getTranslationUnitDecl()]
     = ToContext.getTranslationUnitDecl();
 }

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -331,19 +331,22 @@ llvm::Expected<ASTUnit *> CrossTranslationUnitContext::loadExternalAST(
 
 llvm::Expected<const FunctionDecl *>
 CrossTranslationUnitContext::importDefinition(const FunctionDecl *FD) {
+  assert(FD->hasBody() && "Functions to be imported should have body.");
+
   ASTImporter &Importer = getOrCreateASTImporter(FD->getASTContext());
   auto *ToDecl = cast_or_null<FunctionDecl>(
       Importer.Import(const_cast<FunctionDecl *>(FD)));
-  if (Importer.hasEncounteredUnsupportedNode()) {
+  if (Importer.hasEncounteredUnsupportedConstruct()) {
     if (ToDecl)
       InvalidFunctions.insert(ToDecl);
-    Importer.setEncounteredUnsupportedNode(false);
+    Importer.setEncounteredUnsupportedConstruct(false);
     NumUnsupportedNodeFound++;
     return nullptr;
   }
-  assert(ToDecl);
-  assert(ToDecl->hasBody());
-  assert(FD->hasBody() && "Functions already imported should have body.");
+
+  assert(ToDecl && "Failed to import function.");
+  assert(ToDecl->hasBody() && "Imported functions should have body.");
+
   ++NumGetCTUSuccess;
   return ToDecl;
 }

--- a/test/ASTMerge/std-initializer-list/test.cpp
+++ b/test/ASTMerge/std-initializer-list/test.cpp
@@ -1,3 +1,3 @@
 // RUN: %clang_cc1 -emit-pch -o %t.1.ast %S/Inputs/il.cpp
-// RUN: %clang_cc1 -ast-merge %t.1.ast -fsyntax-only %s 2>&1 | FileCheck --allow-empty %s
-// CHECK-NOT: unsupported AST node
+// RUN: %clang_cc1 -ast-merge %t.1.ast -fsyntax-only -ast-dump %s 2>&1 | FileCheck %s
+// CHECK: CXXStdInitializerList


### PR DESCRIPTION
The previous 'unsupported node" flag is changed to "unsupported construct".
This indicates if there was an unsupported construct (node or other not
importable case) encountered during import.
Normally every kind of AST node should be supported, unless explicitly
marked as not supported. Therefore the generic import functions contain
an assert to find (and implement) not yet supported nodes.