### PR TITLE
[ASTImporter] Improved error detection at import

### DIFF
--- a/.lldb-commit
+++ b/.lldb-commit
@@ -1,1 +1,1 @@
-release_60
+0d6396b747dd8e6aedee1fdac04a1b835b83666a

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -55,8 +55,11 @@ namespace clang {
 
     static char ID;
 
-    ImportError() : Error(Unknown) {}
-    ImportError(ErrorKind Error) : Error(Error) {}
+    ImportError() : Error(Unknown) { }
+    ImportError(const ImportError &Other) : Error(Other.Error) { }
+    ImportError(ErrorKind Error) : Error(Error) { }
+
+    std::string getMessage() const;
 
     void log(raw_ostream &OS) const override;
     std::error_code convertToErrorCode() const override;
@@ -164,7 +167,7 @@ namespace clang {
     template <typename ImportT>
     LLVM_NODISCARD llvm::Error importInto(ImportT &To, const ImportT &From) {
       auto ToOrErr = Import(From);
-      auto Err = ToOrErr.takeError();
+      llvm::Error Err = ToOrErr.takeError();
       if (!Err)
         To = *ToOrErr;
       return Err;
@@ -191,10 +194,8 @@ namespace clang {
     /// "to" context.
     ///
     /// \returns the equivalent declaration in the "to" context, or error.
-    //Expected<Decl *> Import(Decl *FromD);
-    //Expected<Decl *> Import(const Decl *FromD);
-    Decl *Import(Decl *FromD);
-    Decl *Import(const Decl *FromD);
+    Expected<Decl *> Import(Decl *FromD);
+    Expected<Decl *> Import(const Decl *FromD);
 
     /// \brief Return the copy of the given declaration in the "to" context if
     /// it has already been imported from the "from" context.  Otherwise return
@@ -210,21 +211,19 @@ namespace clang {
     ///
     /// \returns the equivalent declaration context in the "to"
     /// context, or error value.
-    llvm::Expected<DeclContext *> ImportContext(DeclContext *FromDC);
+    Expected<DeclContext *> ImportContext(DeclContext *FromDC);
     
     /// \brief Import the given expression from the "from" context into the
     /// "to" context.
     ///
     /// \returns the equivalent expression in the "to" context, or error.
-    //Expected<Expr *> Import(Expr *FromE);
-    Expr *Import(Expr *FromE);
+    Expected<Expr *> Import(Expr *FromE);
 
     /// \brief Import the given statement from the "from" context into the
     /// "to" context.
     ///
     /// \returns the equivalent statement in the "to" context, or error.
-    //Expected<Stmt *> Import(Stmt *FromS);
-    Stmt *Import(Stmt *FromS);
+    Expected<Stmt *> Import(Stmt *FromS);
 
     /// \brief Import the given nested-name-specifier from the "from"
     /// context into the "to" context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -178,8 +178,7 @@ namespace clang {
     /// context.
     ///
     /// \returns the equivalent type in the "to" context, or error.
-    //Expected<QualType> Import(QualType FromT);
-    QualType Import(QualType FromT);
+    Expected<QualType> Import(QualType FromT);
 
     /// \brief Import the given type source information from the
     /// "from" context into the "to" context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -29,6 +29,7 @@ namespace clang {
   class CXXCtorInitializer;
   class CXXBaseSpecifier;
   class Decl;
+  class TranslationUnitDecl;
   class DeclContext;
   class DiagnosticsEngine;
   class Expr;
@@ -102,6 +103,10 @@ namespace clang {
     /// \brief Mapping from the already-imported declarations in the "from"
     /// context to the corresponding declarations in the "to" context.
     llvm::DenseMap<Decl *, Decl *> ImportedDecls;
+
+    /// \brief Mapping from the already-imported declarations in the "to"
+    /// context to the corresponding declarations in the "from" context.
+    llvm::DenseMap<Decl *, Decl *> ImportedFromDecls;
 
     /// \brief Mapping from the already-imported declarations in the "from"
     /// context to the error status of the import of that declaration.
@@ -198,8 +203,12 @@ namespace clang {
 
     /// \brief Return the copy of the given declaration in the "to" context if
     /// it has already been imported from the "from" context.  Otherwise return
-    /// NULL.
+    /// nullptr.
     Decl *GetAlreadyImportedOrNull(Decl *FromD);
+
+    /// \brief Return the translation unit from where the declaration was
+    /// imported. If it does not exist nullptr is returned.
+    TranslationUnitDecl *GetFromTU(Decl *ToD);
 
     /// \brief Return the declaration of the built-in type "__va_list_tag" from
     /// the ASTContext instead of importing it.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -240,8 +240,8 @@ namespace clang {
     /// context into the "to" context.
     ///
     /// \returns the equivalent nested-name-specifier in the "to"
-    /// context.
-    NestedNameSpecifierLoc Import(NestedNameSpecifierLoc FromNNS);
+    /// context, or error.
+    Expected<NestedNameSpecifierLoc> Import(NestedNameSpecifierLoc FromNNS);
 
     /// \brief Import the goven template name from the "from" context into the
     /// "to" context.
@@ -251,8 +251,7 @@ namespace clang {
     /// the "to" context.
     ///
     /// \returns the equivalent source location in the "to" context, or error.
-    //Expected<SourceLocation> Import(SourceLocation FromLoc);
-    SourceLocation Import(SourceLocation FromLoc);
+    Expected<SourceLocation> Import(SourceLocation FromLoc);
 
     /// \brief Import the given source range from the "from" context into
     /// the "to" context.
@@ -282,14 +281,15 @@ namespace clang {
     /// "to" context.
     ///
     /// \returns the equivalent file ID in the source manager of the "to"
-    /// context.
-    FileID Import(FileID);
+    /// context, or error.
+    Expected<FileID> Import(FileID);
 
     /// \brief Import the given C++ constructor initializer from the "from"
     /// context into the "to" context.
     ///
     /// \returns the equivalent initializer in the "to" context.
     CXXCtorInitializer *Import(CXXCtorInitializer *FromInit);
+    //Expected<CXXCtorInitializer *> Import(CXXCtorInitializer *FromInit);
 
     /// \brief Import the given CXXBaseSpecifier from the "from" context into
     /// the "to" context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -155,7 +155,21 @@ namespace clang {
                 bool MinimalImport);
     
     virtual ~ASTImporter();
-    
+
+    /// \brief Import the given object, returns the result.
+    /// 
+    /// \param To Import the object into this variable.
+    /// \param From Object to import.
+    /// \return Error information (success or error).
+    template <typename ImportT>
+    llvm::Error ImportOrError(ImportT &To, const ImportT &From) {
+      auto ToOrErr = Import(From);
+      auto Err = ToOrErr.takeError();
+      if (!Err)
+        To = *ToOrErr;
+      return Err;
+    }
+
     /// \brief Whether the importer will perform a minimal import, creating
     /// to-be-completed forward declarations when possible.
     bool isMinimalImport() const { return Minimal; }
@@ -244,8 +258,7 @@ namespace clang {
     /// the "to" context.
     ///
     /// \returns the equivalent source range in the "to" context, or error.
-    //Expected<SourceRange> Import(SourceRange FromRange);
-    SourceRange Import(SourceRange FromRange);
+    Expected<SourceRange> Import(SourceRange FromRange);
 
     /// \brief Import the given declaration name from the "from"
     /// context into the "to" context.
@@ -284,6 +297,7 @@ namespace clang {
     /// \returns the equivalent CXXBaseSpecifier in the source manager of the
     /// "to" context.
     CXXBaseSpecifier *Import(const CXXBaseSpecifier *FromSpec);
+    //Expected<CXXBaseSpecifier *> Import(const CXXBaseSpecifier *FromSpec);
 
     /// \brief Import the definition of the given declaration, including all of
     /// the declarations it contains.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -211,8 +211,8 @@ namespace clang {
     /// AST context into the "to" AST context.
     ///
     /// \returns the equivalent declaration context in the "to"
-    /// context, or a NULL type if an error occurred.
-    DeclContext *ImportContext(DeclContext *FromDC);
+    /// context, or error value.
+    llvm::Expected<DeclContext *> ImportContext(DeclContext *FromDC);
     
     /// \brief Import the given expression from the "from" context into the
     /// "to" context.
@@ -301,9 +301,7 @@ namespace clang {
 
     /// \brief Import the definition of the given declaration, including all of
     /// the declarations it contains.
-    ///
-    /// This routine is intended to be used 
-    void ImportDefinition(Decl *From);
+    llvm::Error ImportDefinition(Decl *From);
 
     /// \brief Cope with a name conflict when importing a declaration into the
     /// given context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -245,7 +245,7 @@ namespace clang {
 
     /// \brief Import the goven template name from the "from" context into the
     /// "to" context.
-    TemplateName Import(TemplateName From);
+    Expected<TemplateName> Import(TemplateName From);
     
     /// \brief Import the given source location from the "from" context into
     /// the "to" context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -167,10 +167,9 @@ namespace clang {
     template <typename ImportT>
     LLVM_NODISCARD llvm::Error importInto(ImportT &To, const ImportT &From) {
       auto ToOrErr = Import(From);
-      llvm::Error Err = ToOrErr.takeError();
-      if (!Err)
+      if (ToOrErr)
         To = *ToOrErr;
-      return Err;
+      return ToOrErr.takeError();
     }
 
     /// \brief Whether the importer will perform a minimal import, creating

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -265,7 +265,8 @@ namespace clang {
     /// \brief Import the given identifier from the "from" context
     /// into the "to" context.
     ///
-    /// \returns the equivalent identifier in the "to" context.
+    /// \returns the equivalent identifier in the "to" context. Note: It
+    /// returns nullptr only if the FromId was nullptr.
     IdentifierInfo *Import(const IdentifierInfo *FromId);
 
     /// \brief Import the given Objective-C selector from the "from"

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -186,8 +186,7 @@ namespace clang {
     ///
     /// \returns the equivalent type source information in the "to"
     /// context, or error.
-    //Expected<TypeSourceInfo *> Import(TypeSourceInfo *FromTSI);
-    TypeSourceInfo *Import(TypeSourceInfo *FromTSI);
+    Expected<TypeSourceInfo *> Import(TypeSourceInfo *FromTSI);
 
     /// \brief Import the given declaration from the "from" context into the 
     /// "to" context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -162,7 +162,7 @@ namespace clang {
     /// \param From Object to import.
     /// \return Error information (success or error).
     template <typename ImportT>
-    llvm::Error ImportOrError(ImportT &To, const ImportT &From) {
+    LLVM_NODISCARD llvm::Error importInto(ImportT &To, const ImportT &From) {
       auto ToOrErr = Import(From);
       auto Err = ToOrErr.takeError();
       if (!Err)
@@ -233,8 +233,7 @@ namespace clang {
     ///
     /// \returns the equivalent nested-name-specifier in the "to"
     /// context, or error.
-    //Expected<NestedNameSpecifier *> Import(NestedNameSpecifier *FromNNS);
-    NestedNameSpecifier *Import(NestedNameSpecifier *FromNNS);
+    Expected<NestedNameSpecifier *> Import(NestedNameSpecifier *FromNNS);
 
     /// \brief Import the given nested-name-specifier from the "from"
     /// context into the "to" context.
@@ -287,17 +286,15 @@ namespace clang {
     /// \brief Import the given C++ constructor initializer from the "from"
     /// context into the "to" context.
     ///
-    /// \returns the equivalent initializer in the "to" context.
-    CXXCtorInitializer *Import(CXXCtorInitializer *FromInit);
-    //Expected<CXXCtorInitializer *> Import(CXXCtorInitializer *FromInit);
+    /// \returns the equivalent initializer in the "to" context, or error.
+    Expected<CXXCtorInitializer *> Import(CXXCtorInitializer *FromInit);
 
     /// \brief Import the given CXXBaseSpecifier from the "from" context into
     /// the "to" context.
     ///
     /// \returns the equivalent CXXBaseSpecifier in the source manager of the
-    /// "to" context.
-    CXXBaseSpecifier *Import(const CXXBaseSpecifier *FromSpec);
-    //Expected<CXXBaseSpecifier *> Import(const CXXBaseSpecifier *FromSpec);
+    /// "to" context, or error.
+    Expected<CXXBaseSpecifier *> Import(const CXXBaseSpecifier *FromSpec);
 
     /// \brief Import the definition of the given declaration, including all of
     /// the declarations it contains.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -296,7 +296,7 @@ namespace clang {
 
     /// \brief Import the definition of the given declaration, including all of
     /// the declarations it contains.
-    llvm::Error ImportDefinition(Decl *From);
+    LLVM_NODISCARD llvm::Error ImportDefinition(Decl *From);
 
     /// \brief Cope with a name conflict when importing a declaration into the
     /// given context.

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -374,6 +374,8 @@ namespace clang {
 
     Error ImportTemplateInformation(FunctionDecl *FromFD, FunctionDecl *ToFD);
 
+    bool hasSameVisibilityContext(FunctionDecl *Found, FunctionDecl *From);
+
     bool IsStructuralMatch(Decl *From, Decl *To, bool Complain);
     bool IsStructuralMatch(RecordDecl *FromRecord, RecordDecl *ToRecord,
                            bool Complain = true);
@@ -2937,6 +2939,20 @@ ASTNodeImporter::FindFunctionTemplateSpecialization(FunctionDecl *FromFD) {
   return FoundSpec;
 }
 
+bool ASTNodeImporter::hasSameVisibilityContext(FunctionDecl *Found,
+                                               FunctionDecl *From) {
+  if (From->hasExternalFormalLinkage())
+    return Found->hasExternalFormalLinkage();
+  else if (Importer.GetFromTU(Found) == From->getTranslationUnitDecl()) {
+    if (From->isInAnonymousNamespace())
+      return Found->isInAnonymousNamespace();
+    else
+      return !Found->isInAnonymousNamespace() &&
+             !Found->hasExternalFormalLinkage();
+  }
+  return false;
+}
+
 ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
 
   SmallVector<Decl*, 2> Redecls = getCanonicalForwardRedeclChain(D);
@@ -3001,32 +3017,32 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
       }
 
       if (FunctionDecl *FoundFunction = dyn_cast<FunctionDecl>(Found)) {
-        if (FoundFunction->hasExternalFormalLinkage() &&
-            D->hasExternalFormalLinkage()) {
-          if (IsStructuralMatch(D, FoundFunction)) {
-            const FunctionDecl *Definition = nullptr;
-            if (D->doesThisDeclarationHaveABody() &&
-                FoundFunction->hasBody(Definition))
-              return Importer.MapImported(
-                  D, const_cast<FunctionDecl *>(Definition));
-            FoundByLookup = FoundFunction;
-            break;
-          }
 
-          // FIXME: Check for overloading more carefully, e.g., by boosting
-          // Sema::IsOverload out to the AST library.
+        if (!hasSameVisibilityContext(FoundFunction, D))
+          continue;
 
-          // Function overloading is okay in C++.
-          if (Importer.getToContext().getLangOpts().CPlusPlus)
-            continue;
-
-          // Complain about inconsistent function types.
-          Importer.ToDiag(Loc, diag::err_odr_function_type_inconsistent)
-            << Name << D->getType() << FoundFunction->getType();
-          Importer.ToDiag(FoundFunction->getLocation(), 
-                          diag::note_odr_value_here)
-            << FoundFunction->getType();
+        if (IsStructuralMatch(D, FoundFunction)) {
+          const FunctionDecl *Definition = nullptr;
+          if (D->doesThisDeclarationHaveABody() &&
+              FoundFunction->hasBody(Definition))
+            return Importer.MapImported(D,
+                                        const_cast<FunctionDecl *>(Definition));
+          FoundByLookup = FoundFunction;
+          break;
         }
+
+        // FIXME: Check for overloading more carefully, e.g., by boosting
+        // Sema::IsOverload out to the AST library.
+
+        // Function overloading is okay in C++.
+        if (Importer.getToContext().getLangOpts().CPlusPlus)
+          continue;
+
+        // Complain about inconsistent function types.
+        Importer.ToDiag(Loc, diag::err_odr_function_type_inconsistent)
+            << Name << D->getType() << FoundFunction->getType();
+        Importer.ToDiag(FoundFunction->getLocation(), diag::note_odr_value_here)
+            << FoundFunction->getType();
       }
 
       ConflictingDecls.push_back(Found);
@@ -7733,6 +7749,13 @@ Decl *ASTImporter::GetAlreadyImportedOrNull(Decl *FromD) {
   }
 }
 
+TranslationUnitDecl *ASTImporter::GetFromTU(Decl *ToD) {
+  auto FromDPos = ImportedFromDecls.find(ToD);
+  if (FromDPos == ImportedFromDecls.end())
+    return nullptr;
+  return FromDPos->second->getTranslationUnitDecl();
+}
+
 Decl *ASTImporter::GetVAListTag(Decl *FromD) {
   if (isa<TypedefDecl>(FromD) &&
       ToContext.getTargetInfo().getBuiltinVaListKind() ==
@@ -8495,6 +8518,9 @@ Decl *ASTImporter::MapImported(Decl *From, Decl *To) {
   if (Pos != ImportedDecls.end())
     return Pos->second;
   ImportedDecls[From] = To;
+  // This mapping should be maintained only in this function. Therefore do not
+  // check for additional consistency.
+  ImportedFromDecls[To] = From;
   return To;
 }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3573,7 +3573,7 @@ ExpectedDecl ASTNodeImporter::VisitVarDecl(VarDecl *D) {
                                                 FoundVar->getType())) {
 
             // The VarDecl in the "From" context has a definition, but in the
-            // "To" context we already has a definition.
+            // "To" context we already have a definition.
             VarDecl *FoundDef = FoundVar->getDefinition();
             if (D->isThisDeclarationADefinition() && FoundDef)
               // FIXME Check for ODR error if the two definitions have
@@ -3581,7 +3581,7 @@ ExpectedDecl ASTNodeImporter::VisitVarDecl(VarDecl *D) {
               return Importer.MapImported(D, FoundDef);
 
             // The VarDecl in the "From" context has an initializer, but in the
-            // "To" context we already has an initializer.
+            // "To" context we already have an initializer.
             const VarDecl *FoundDInit = nullptr;
             if (D->getInit() && FoundVar->getAnyInitializer(FoundDInit))
               // FIXME Diagnose ODR error if the two initializers are different?

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -82,7 +82,9 @@ namespace clang {
       To->setIsUsed();
   }
 
-  class ASTNodeImporter : public TypeVisitor<ASTNodeImporter, QualType>,
+  using ExpectedType = llvm::Expected<QualType>;
+
+  class ASTNodeImporter : public TypeVisitor<ASTNodeImporter, ExpectedType>,
                           public DeclVisitor<ASTNodeImporter, Decl *>,
                           public StmtVisitor<ASTNodeImporter, Stmt *> {
     ASTImporter &Importer;
@@ -164,55 +166,57 @@ namespace clang {
 
   public:
     explicit ASTNodeImporter(ASTImporter &Importer) : Importer(Importer) { }
-    using TypeVisitor<ASTNodeImporter, QualType>::Visit;
+    using TypeVisitor<ASTNodeImporter, ExpectedType>::Visit;
     using DeclVisitor<ASTNodeImporter, Decl *>::Visit;
     using StmtVisitor<ASTNodeImporter, Stmt *>::Visit;
 
     // Importing types
-    QualType VisitType(const Type *T);
-    QualType VisitAtomicType(const AtomicType *T);
-    QualType VisitBuiltinType(const BuiltinType *T);
-    QualType VisitDecayedType(const DecayedType *T);
-    QualType VisitComplexType(const ComplexType *T);
-    QualType VisitPointerType(const PointerType *T);
-    QualType VisitBlockPointerType(const BlockPointerType *T);
-    QualType VisitLValueReferenceType(const LValueReferenceType *T);
-    QualType VisitRValueReferenceType(const RValueReferenceType *T);
-    QualType VisitMemberPointerType(const MemberPointerType *T);
-    QualType VisitConstantArrayType(const ConstantArrayType *T);
-    QualType VisitIncompleteArrayType(const IncompleteArrayType *T);
-    QualType VisitVariableArrayType(const VariableArrayType *T);
-    QualType VisitDependentSizedArrayType(const DependentSizedArrayType *T);
+    ExpectedType VisitType(const Type *T);
+    ExpectedType VisitAtomicType(const AtomicType *T);
+    ExpectedType VisitBuiltinType(const BuiltinType *T);
+    ExpectedType VisitDecayedType(const DecayedType *T);
+    ExpectedType VisitComplexType(const ComplexType *T);
+    ExpectedType VisitPointerType(const PointerType *T);
+    ExpectedType VisitBlockPointerType(const BlockPointerType *T);
+    ExpectedType VisitLValueReferenceType(const LValueReferenceType *T);
+    ExpectedType VisitRValueReferenceType(const RValueReferenceType *T);
+    ExpectedType VisitMemberPointerType(const MemberPointerType *T);
+    ExpectedType VisitConstantArrayType(const ConstantArrayType *T);
+    ExpectedType VisitIncompleteArrayType(const IncompleteArrayType *T);
+    ExpectedType VisitVariableArrayType(const VariableArrayType *T);
+    ExpectedType VisitDependentSizedArrayType(const DependentSizedArrayType *T);
     // FIXME: DependentSizedExtVectorType
-    QualType VisitVectorType(const VectorType *T);
-    QualType VisitExtVectorType(const ExtVectorType *T);
-    QualType VisitFunctionNoProtoType(const FunctionNoProtoType *T);
-    QualType VisitFunctionProtoType(const FunctionProtoType *T);
-    QualType VisitUnresolvedUsingType(const UnresolvedUsingType *T);
-    QualType VisitParenType(const ParenType *T);
-    QualType VisitTypedefType(const TypedefType *T);
-    QualType VisitTypeOfExprType(const TypeOfExprType *T);
+    ExpectedType VisitVectorType(const VectorType *T);
+    ExpectedType VisitExtVectorType(const ExtVectorType *T);
+    ExpectedType VisitFunctionNoProtoType(const FunctionNoProtoType *T);
+    ExpectedType VisitFunctionProtoType(const FunctionProtoType *T);
+    ExpectedType VisitUnresolvedUsingType(const UnresolvedUsingType *T);
+    ExpectedType VisitParenType(const ParenType *T);
+    ExpectedType VisitTypedefType(const TypedefType *T);
+    ExpectedType VisitTypeOfExprType(const TypeOfExprType *T);
     // FIXME: DependentTypeOfExprType
-    QualType VisitTypeOfType(const TypeOfType *T);
-    QualType VisitDecltypeType(const DecltypeType *T);
-    QualType VisitUnaryTransformType(const UnaryTransformType *T);
-    QualType VisitAutoType(const AutoType *T);
-    QualType VisitInjectedClassNameType(const InjectedClassNameType *T);
+    ExpectedType VisitTypeOfType(const TypeOfType *T);
+    ExpectedType VisitDecltypeType(const DecltypeType *T);
+    ExpectedType VisitUnaryTransformType(const UnaryTransformType *T);
+    ExpectedType VisitAutoType(const AutoType *T);
+    ExpectedType VisitInjectedClassNameType(const InjectedClassNameType *T);
     // FIXME: DependentDecltypeType
-    QualType VisitRecordType(const RecordType *T);
-    QualType VisitEnumType(const EnumType *T);
-    QualType VisitAttributedType(const AttributedType *T);
-    QualType VisitTemplateTypeParmType(const TemplateTypeParmType *T);
-    QualType VisitSubstTemplateTypeParmType(const SubstTemplateTypeParmType *T);
-    QualType VisitTemplateSpecializationType(const TemplateSpecializationType *T);
-    QualType VisitElaboratedType(const ElaboratedType *T);
-    QualType VisitDependentNameType(const DependentNameType *T);
-    QualType VisitPackExpansionType(const PackExpansionType *T);
-    QualType VisitDependentTemplateSpecializationType(
+    ExpectedType VisitRecordType(const RecordType *T);
+    ExpectedType VisitEnumType(const EnumType *T);
+    ExpectedType VisitAttributedType(const AttributedType *T);
+    ExpectedType VisitTemplateTypeParmType(const TemplateTypeParmType *T);
+    ExpectedType VisitSubstTemplateTypeParmType(
+        const SubstTemplateTypeParmType *T);
+    ExpectedType VisitTemplateSpecializationType(
+        const TemplateSpecializationType *T);
+    ExpectedType VisitElaboratedType(const ElaboratedType *T);
+    ExpectedType VisitDependentNameType(const DependentNameType *T);
+    ExpectedType VisitPackExpansionType(const PackExpansionType *T);
+    ExpectedType VisitDependentTemplateSpecializationType(
         const DependentTemplateSpecializationType *T);
-    QualType VisitObjCInterfaceType(const ObjCInterfaceType *T);
-    QualType VisitObjCObjectType(const ObjCObjectType *T);
-    QualType VisitObjCObjectPointerType(const ObjCObjectPointerType *T);
+    ExpectedType VisitObjCInterfaceType(const ObjCInterfaceType *T);
+    ExpectedType VisitObjCObjectType(const ObjCObjectType *T);
+    ExpectedType VisitObjCObjectPointerType(const ObjCObjectPointerType *T);
 
     // Importing declarations
     Error ImportDeclParts(
@@ -608,26 +612,20 @@ ASTNodeImporter::ImportFunctionTemplateWithTemplateArgsFromSpecialization(
 
 using namespace clang;
 
-// FIXME: Temporary function until the Err can be returned from caller function.
-QualType discErrorType(Error Err) {
-  // handle error ...
-  return QualType();
+ExpectedType ASTNodeImporter::VisitType(const Type *T) {
+  llvm_unreachable("Unsupported Type at import");
+  //return make_error<ImportError>();
 }
 
-QualType ASTNodeImporter::VisitType(const Type *T) {
-  assert(false && "Unsupported Type at import");
-  return QualType();
-}
-
-QualType ASTNodeImporter::VisitAtomicType(const AtomicType *T){
+ExpectedType ASTNodeImporter::VisitAtomicType(const AtomicType *T){
   auto UnderlyingTypeOrErr = Importer.Import(T->getValueType());
   if (!UnderlyingTypeOrErr)
-    return QualType();
+    return UnderlyingTypeOrErr.takeError();
 
   return Importer.getToContext().getAtomicType(*UnderlyingTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitBuiltinType(const BuiltinType *T) {
+ExpectedType ASTNodeImporter::VisitBuiltinType(const BuiltinType *T) {
   switch (T->getKind()) {
 #define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
   case BuiltinType::Id: \
@@ -672,77 +670,79 @@ QualType ASTNodeImporter::VisitBuiltinType(const BuiltinType *T) {
   llvm_unreachable("Invalid BuiltinType Kind!");
 }
 
-QualType ASTNodeImporter::VisitDecayedType(const DecayedType *T) {
+ExpectedType ASTNodeImporter::VisitDecayedType(const DecayedType *T) {
   auto ToOriginalTypeOrErr = Importer.Import(T->getOriginalType());
   if (!ToOriginalTypeOrErr)
-    return discErrorType(ToOriginalTypeOrErr.takeError());
+    return ToOriginalTypeOrErr.takeError();
 
   return Importer.getToContext().getDecayedType(*ToOriginalTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitComplexType(const ComplexType *T) {
+ExpectedType ASTNodeImporter::VisitComplexType(const ComplexType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   return Importer.getToContext().getComplexType(*ToElementTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitPointerType(const PointerType *T) {
+ExpectedType ASTNodeImporter::VisitPointerType(const PointerType *T) {
   auto ToPointeeTypeOrErr = Importer.Import(T->getPointeeType());
   if (!ToPointeeTypeOrErr)
-    return discErrorType(ToPointeeTypeOrErr.takeError());
+    return ToPointeeTypeOrErr.takeError();
 
   return Importer.getToContext().getPointerType(*ToPointeeTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitBlockPointerType(const BlockPointerType *T) {
+ExpectedType ASTNodeImporter::VisitBlockPointerType(const BlockPointerType *T) {
   // FIXME: Check for blocks support in "to" context.
   auto ToPointeeTypeOrErr = Importer.Import(T->getPointeeType());
   if (!ToPointeeTypeOrErr)
-    return discErrorType(ToPointeeTypeOrErr.takeError());
+    return ToPointeeTypeOrErr.takeError();
 
   return Importer.getToContext().getBlockPointerType(*ToPointeeTypeOrErr);
 }
 
-QualType
+ExpectedType
 ASTNodeImporter::VisitLValueReferenceType(const LValueReferenceType *T) {
   // FIXME: Check for C++ support in "to" context.
   auto ToPointeeTypeOrErr = Importer.Import(T->getPointeeTypeAsWritten());
   if (!ToPointeeTypeOrErr)
-    return discErrorType(ToPointeeTypeOrErr.takeError());
+    return ToPointeeTypeOrErr.takeError();
 
   return Importer.getToContext().getLValueReferenceType(*ToPointeeTypeOrErr);
 }
 
-QualType
+ExpectedType
 ASTNodeImporter::VisitRValueReferenceType(const RValueReferenceType *T) {
   // FIXME: Check for C++0x support in "to" context.
   auto ToPointeeTypeOrErr = Importer.Import(T->getPointeeTypeAsWritten());
   if (!ToPointeeTypeOrErr)
-    return discErrorType(ToPointeeTypeOrErr.takeError());
+    return ToPointeeTypeOrErr.takeError();
 
   return Importer.getToContext().getRValueReferenceType(*ToPointeeTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitMemberPointerType(const MemberPointerType *T) {
+ExpectedType
+ASTNodeImporter::VisitMemberPointerType(const MemberPointerType *T) {
   // FIXME: Check for C++ support in "to" context.
   auto ToPointeeTypeOrErr = Importer.Import(T->getPointeeType());
   if (!ToPointeeTypeOrErr)
-    return discErrorType(ToPointeeTypeOrErr.takeError());
+    return ToPointeeTypeOrErr.takeError();
 
   auto ClassTypeOrErr = Importer.Import(QualType(T->getClass(), 0));
   if (!ClassTypeOrErr)
-    return discErrorType(ClassTypeOrErr.takeError());
+    return ClassTypeOrErr.takeError();
 
   return Importer.getToContext().getMemberPointerType(
       *ToPointeeTypeOrErr, (*ClassTypeOrErr).getTypePtr());
 }
 
-QualType ASTNodeImporter::VisitConstantArrayType(const ConstantArrayType *T) {
+ExpectedType
+ASTNodeImporter::VisitConstantArrayType(const ConstantArrayType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   return Importer.getToContext().getConstantArrayType(*ToElementTypeOrErr,
                                                       T->getSize(),
@@ -750,30 +750,30 @@ QualType ASTNodeImporter::VisitConstantArrayType(const ConstantArrayType *T) {
                                                T->getIndexTypeCVRQualifiers());
 }
 
-QualType
+ExpectedType
 ASTNodeImporter::VisitIncompleteArrayType(const IncompleteArrayType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   return Importer.getToContext().getIncompleteArrayType(*ToElementTypeOrErr,
                                                         T->getSizeModifier(),
                                                 T->getIndexTypeCVRQualifiers());
 }
 
-QualType ASTNodeImporter::VisitVariableArrayType(const VariableArrayType *T) {
+ExpectedType
+ASTNodeImporter::VisitVariableArrayType(const VariableArrayType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   Expr *Size = Importer.Import(T->getSizeExpr());
   if (!Size)
-    return QualType();
+    return make_error<ImportError>();
 
   auto BracketsOrErr =  Importer.Import(T->getBracketsRange());
   if (!BracketsOrErr)
-    // FIXME: return the error
-    return QualType();
+    return BracketsOrErr.takeError();
 
   return Importer.getToContext().getVariableArrayType(*ToElementTypeOrErr, Size,
                                                       T->getSizeModifier(),
@@ -781,69 +781,70 @@ QualType ASTNodeImporter::VisitVariableArrayType(const VariableArrayType *T) {
                                                       *BracketsOrErr);
 }
 
-QualType ASTNodeImporter::VisitDependentSizedArrayType(
+ExpectedType ASTNodeImporter::VisitDependentSizedArrayType(
     const DependentSizedArrayType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   // SizeExpr may be null if size is not specified directly.
   // For example, 'int a[]'.
   Expr *Size = Importer.Import(T->getSizeExpr());
   if (!Size && T->getSizeExpr())
-    return QualType();
+    return make_error<ImportError>();
 
   auto BracketsOrErr = Importer.Import(T->getBracketsRange());
   if (!BracketsOrErr)
-    return QualType();
+    return BracketsOrErr.takeError();
 
   return Importer.getToContext().getDependentSizedArrayType(
       *ToElementTypeOrErr, Size, T->getSizeModifier(),
       T->getIndexTypeCVRQualifiers(), *BracketsOrErr);
 }
 
-QualType ASTNodeImporter::VisitVectorType(const VectorType *T) {
+ExpectedType ASTNodeImporter::VisitVectorType(const VectorType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   return Importer.getToContext().getVectorType(*ToElementTypeOrErr,
                                                T->getNumElements(),
                                                T->getVectorKind());
 }
 
-QualType ASTNodeImporter::VisitExtVectorType(const ExtVectorType *T) {
+ExpectedType ASTNodeImporter::VisitExtVectorType(const ExtVectorType *T) {
   auto ToElementTypeOrErr = Importer.Import(T->getElementType());
   if (!ToElementTypeOrErr)
-    return discErrorType(ToElementTypeOrErr.takeError());
+    return ToElementTypeOrErr.takeError();
 
   return Importer.getToContext().getExtVectorType(*ToElementTypeOrErr,
                                                   T->getNumElements());
 }
 
-QualType
+ExpectedType
 ASTNodeImporter::VisitFunctionNoProtoType(const FunctionNoProtoType *T) {
   // FIXME: What happens if we're importing a function without a prototype 
   // into C++? Should we make it variadic?
   auto ToReturnTypeOrErr = Importer.Import(T->getReturnType());
   if (!ToReturnTypeOrErr)
-    return discErrorType(ToReturnTypeOrErr.takeError());
+    return ToReturnTypeOrErr.takeError();
 
   return Importer.getToContext().getFunctionNoProtoType(*ToReturnTypeOrErr,
                                                         T->getExtInfo());
 }
 
-QualType ASTNodeImporter::VisitFunctionProtoType(const FunctionProtoType *T) {
+ExpectedType
+ASTNodeImporter::VisitFunctionProtoType(const FunctionProtoType *T) {
   auto ToReturnTypeOrErr = Importer.Import(T->getReturnType());
   if (!ToReturnTypeOrErr)
-    return discErrorType(ToReturnTypeOrErr.takeError());
+    return ToReturnTypeOrErr.takeError();
 
   // Import argument types
   SmallVector<QualType, 4> ArgTypes;
   for (const auto &A : T->param_types()) {
     auto TyOrErr = Importer.Import(A);
     if (!TyOrErr)
-      return discErrorType(TyOrErr.takeError());
+      return TyOrErr.takeError();
     ArgTypes.push_back(*TyOrErr);
   }
   
@@ -852,7 +853,7 @@ QualType ASTNodeImporter::VisitFunctionProtoType(const FunctionProtoType *T) {
   for (const auto &E : T->exceptions()) {
     auto TyOrErr = Importer.Import(E);
     if (!TyOrErr)
-      return discErrorType(TyOrErr.takeError());
+      return TyOrErr.takeError();
     ExceptionTypes.push_back(*TyOrErr);
   }
 
@@ -877,103 +878,104 @@ QualType ASTNodeImporter::VisitFunctionProtoType(const FunctionProtoType *T) {
       *ToReturnTypeOrErr, ArgTypes, ToEPI);
 }
 
-QualType ASTNodeImporter::VisitUnresolvedUsingType(
+ExpectedType ASTNodeImporter::VisitUnresolvedUsingType(
     const UnresolvedUsingType *T) {
   UnresolvedUsingTypenameDecl *ToD = cast_or_null<UnresolvedUsingTypenameDecl>(
         Importer.Import(T->getDecl()));
   if (!ToD)
-    return QualType();
+    return make_error<ImportError>();
 
   UnresolvedUsingTypenameDecl *ToPrevD =
       cast_or_null<UnresolvedUsingTypenameDecl>(
         Importer.Import(T->getDecl()->getPreviousDecl()));
   if (!ToPrevD && T->getDecl()->getPreviousDecl())
-    return QualType();
+    return make_error<ImportError>();
 
   return Importer.getToContext().getTypeDeclType(ToD, ToPrevD);
 }
 
-QualType ASTNodeImporter::VisitParenType(const ParenType *T) {
+ExpectedType ASTNodeImporter::VisitParenType(const ParenType *T) {
   auto ToInnerTypeOrErr = Importer.Import(T->getInnerType());
   if (!ToInnerTypeOrErr)
-    return discErrorType(ToInnerTypeOrErr.takeError());
+    return ToInnerTypeOrErr.takeError();
 
   return Importer.getToContext().getParenType(*ToInnerTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitTypedefType(const TypedefType *T) {
+ExpectedType ASTNodeImporter::VisitTypedefType(const TypedefType *T) {
   TypedefNameDecl *ToDecl
              = dyn_cast_or_null<TypedefNameDecl>(Importer.Import(T->getDecl()));
   if (!ToDecl)
-    return QualType();
+    return make_error<ImportError>();
   
   return Importer.getToContext().getTypeDeclType(ToDecl);
 }
 
-QualType ASTNodeImporter::VisitTypeOfExprType(const TypeOfExprType *T) {
+ExpectedType ASTNodeImporter::VisitTypeOfExprType(const TypeOfExprType *T) {
   Expr *ToExpr = Importer.Import(T->getUnderlyingExpr());
   if (!ToExpr)
-    return QualType();
+    return make_error<ImportError>();
   
   return Importer.getToContext().getTypeOfExprType(ToExpr);
 }
 
-QualType ASTNodeImporter::VisitTypeOfType(const TypeOfType *T) {
+ExpectedType ASTNodeImporter::VisitTypeOfType(const TypeOfType *T) {
   auto ToUnderlyingTypeOrErr = Importer.Import(T->getUnderlyingType());
   if (!ToUnderlyingTypeOrErr)
-    return discErrorType(ToUnderlyingTypeOrErr.takeError());
+    return ToUnderlyingTypeOrErr.takeError();
 
   return Importer.getToContext().getTypeOfType(*ToUnderlyingTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitDecltypeType(const DecltypeType *T) {
+ExpectedType ASTNodeImporter::VisitDecltypeType(const DecltypeType *T) {
   // FIXME: Make sure that the "to" context supports C++0x!
   Expr *ToExpr = Importer.Import(T->getUnderlyingExpr());
   if (!ToExpr)
-    return QualType();
+    return make_error<ImportError>();
 
   auto ToUnderlyingTypeOrErr = Importer.Import(T->getUnderlyingType());
   if (!ToUnderlyingTypeOrErr)
-    return discErrorType(ToUnderlyingTypeOrErr.takeError());
+    return ToUnderlyingTypeOrErr.takeError();
 
   return Importer.getToContext().getDecltypeType(
       ToExpr, *ToUnderlyingTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitUnaryTransformType(const UnaryTransformType *T) {
+ExpectedType
+ASTNodeImporter::VisitUnaryTransformType(const UnaryTransformType *T) {
   auto ToBaseTypeOrErr = Importer.Import(T->getBaseType());
   if (!ToBaseTypeOrErr)
-    return discErrorType(ToBaseTypeOrErr.takeError());
+    return ToBaseTypeOrErr.takeError();
 
   auto ToUnderlyingTypeOrErr = Importer.Import(T->getUnderlyingType());
   if (!ToUnderlyingTypeOrErr)
-    return discErrorType(ToUnderlyingTypeOrErr.takeError());
+    return ToUnderlyingTypeOrErr.takeError();
 
   return Importer.getToContext().getUnaryTransformType(*ToBaseTypeOrErr,
                                                        *ToUnderlyingTypeOrErr,
                                                        T->getUTTKind());
 }
 
-QualType ASTNodeImporter::VisitAutoType(const AutoType *T) {
+ExpectedType ASTNodeImporter::VisitAutoType(const AutoType *T) {
   // FIXME: Make sure that the "to" context supports C++11!
   auto ToDeducedTypeOrErr = Importer.Import(T->getDeducedType());
   if (!ToDeducedTypeOrErr)
-    return discErrorType(ToDeducedTypeOrErr.takeError());
+    return ToDeducedTypeOrErr.takeError();
 
   return Importer.getToContext().getAutoType(*ToDeducedTypeOrErr,
                                              T->getKeyword(),
                                              /*IsDependent*/false);
 }
 
-QualType ASTNodeImporter::VisitInjectedClassNameType(
+ExpectedType ASTNodeImporter::VisitInjectedClassNameType(
     const InjectedClassNameType *T) {
   CXXRecordDecl *D = cast_or_null<CXXRecordDecl>(Importer.Import(T->getDecl()));
   if (!D)
-    return QualType();
+    return make_error<ImportError>();
 
   auto ToInjTypeOrErr = Importer.Import(T->getInjectedSpecializationType());
   if (!ToInjTypeOrErr)
-    return discErrorType(ToInjTypeOrErr.takeError());
+    return ToInjTypeOrErr.takeError();
 
   // FIXME: ASTContext::getInjectedClassNameType is not suitable for AST reading
   // See comments in InjectedClassNameType definition for details
@@ -987,73 +989,74 @@ QualType ASTNodeImporter::VisitInjectedClassNameType(
                   InjectedClassNameType(D, *ToInjTypeOrErr), 0);
 }
 
-QualType ASTNodeImporter::VisitRecordType(const RecordType *T) {
+ExpectedType ASTNodeImporter::VisitRecordType(const RecordType *T) {
   RecordDecl *ToDecl
     = dyn_cast_or_null<RecordDecl>(Importer.Import(T->getDecl()));
   if (!ToDecl)
-    return QualType();
+    return make_error<ImportError>();
 
   return Importer.getToContext().getTagDeclType(ToDecl);
 }
 
-QualType ASTNodeImporter::VisitEnumType(const EnumType *T) {
+ExpectedType ASTNodeImporter::VisitEnumType(const EnumType *T) {
   EnumDecl *ToDecl
     = dyn_cast_or_null<EnumDecl>(Importer.Import(T->getDecl()));
   if (!ToDecl)
-    return QualType();
+    return make_error<ImportError>();
 
   return Importer.getToContext().getTagDeclType(ToDecl);
 }
 
-QualType ASTNodeImporter::VisitAttributedType(const AttributedType *T) {
+ExpectedType ASTNodeImporter::VisitAttributedType(const AttributedType *T) {
   auto ToModifiedTypeOrErr = Importer.Import(T->getModifiedType());
   if (!ToModifiedTypeOrErr)
-    return discErrorType(ToModifiedTypeOrErr.takeError());
+    return ToModifiedTypeOrErr.takeError();
   auto ToEquivalentTypeOrErr = Importer.Import(T->getEquivalentType());
   if (!ToEquivalentTypeOrErr)
-    return discErrorType(ToEquivalentTypeOrErr.takeError());
+    return ToEquivalentTypeOrErr.takeError();
 
   return Importer.getToContext().getAttributedType(T->getAttrKind(),
       *ToModifiedTypeOrErr, *ToEquivalentTypeOrErr);
 }
 
 
-QualType ASTNodeImporter::VisitTemplateTypeParmType(
+ExpectedType ASTNodeImporter::VisitTemplateTypeParmType(
     const TemplateTypeParmType *T) {
   TemplateTypeParmDecl *ParmDecl =
       cast_or_null<TemplateTypeParmDecl>(Importer.Import(T->getDecl()));
   if (!ParmDecl && T->getDecl())
-    return QualType();
+    return make_error<ImportError>();
 
   return Importer.getToContext().getTemplateTypeParmType(
         T->getDepth(), T->getIndex(), T->isParameterPack(), ParmDecl);
 }
 
-QualType ASTNodeImporter::VisitSubstTemplateTypeParmType(
+ExpectedType ASTNodeImporter::VisitSubstTemplateTypeParmType(
     const SubstTemplateTypeParmType *T) {
   auto ReplacedOrErr = Importer.Import(QualType(T->getReplacedParameter(), 0));
   if (!ReplacedOrErr)
-    return discErrorType(ReplacedOrErr.takeError());
+    return ReplacedOrErr.takeError();
   const TemplateTypeParmType *Replaced =
       cast<TemplateTypeParmType>((*ReplacedOrErr).getTypePtr());
 
   auto ToReplacementTypeOrErr = Importer.Import(T->getReplacementType());
   if (!ToReplacementTypeOrErr)
-    return discErrorType(ToReplacementTypeOrErr.takeError());
+    return ToReplacementTypeOrErr.takeError();
 
   return Importer.getToContext().getSubstTemplateTypeParmType(
         Replaced, (*ToReplacementTypeOrErr).getCanonicalType());
 }
 
-QualType ASTNodeImporter::VisitTemplateSpecializationType(
+ExpectedType ASTNodeImporter::VisitTemplateSpecializationType(
                                        const TemplateSpecializationType *T) {
   auto ToTemplateOrErr = Importer.Import(T->getTemplateName());
   if (!ToTemplateOrErr)
-    return QualType();
+    return ToTemplateOrErr.takeError();
   
   SmallVector<TemplateArgument, 2> ToTemplateArgs;
-  if (ImportTemplateArguments(T->getArgs(), T->getNumArgs(), ToTemplateArgs))
-    return QualType();
+  if (Error Err = ImportTemplateArguments(
+      T->getArgs(), T->getNumArgs(), ToTemplateArgs))
+    return std::move(Err);
   
   QualType ToCanonType;
   if (!QualType(T, 0).isCanonical()) {
@@ -1062,43 +1065,42 @@ QualType ASTNodeImporter::VisitTemplateSpecializationType(
     if (auto TyOrErr = Importer.Import(FromCanonType))
       ToCanonType = *TyOrErr;
     else
-      return discErrorType(TyOrErr.takeError());
+      return TyOrErr.takeError();
   }
   return Importer.getToContext().getTemplateSpecializationType(*ToTemplateOrErr,
                                                                ToTemplateArgs,
                                                                ToCanonType);
 }
 
-QualType ASTNodeImporter::VisitElaboratedType(const ElaboratedType *T) {
+ExpectedType ASTNodeImporter::VisitElaboratedType(const ElaboratedType *T) {
   // Note: the qualifier in an ElaboratedType is optional.
   auto ToQualifierOrErr = Importer.Import(T->getQualifier());
   if (!ToQualifierOrErr)
-    return QualType();
+    return ToQualifierOrErr.takeError();
 
   auto ToNamedTypeOrErr = Importer.Import(T->getNamedType());
   if (!ToNamedTypeOrErr)
-    return discErrorType(ToNamedTypeOrErr.takeError());
+    return ToNamedTypeOrErr.takeError();
 
   return Importer.getToContext().getElaboratedType(T->getKeyword(),
                                                    *ToQualifierOrErr,
                                                    *ToNamedTypeOrErr);
 }
 
-QualType ASTNodeImporter::VisitDependentNameType(const DependentNameType *T) {
+ExpectedType
+ASTNodeImporter::VisitDependentNameType(const DependentNameType *T) {
   auto NNSOrErr = Importer.Import(T->getQualifier());
   if (!NNSOrErr)
-    return QualType();
+    return NNSOrErr.takeError();
 
   IdentifierInfo *Name = Importer.Import(T->getIdentifier());
-  if (!Name && T->getIdentifier())
-    return QualType();
 
   QualType Canon;
   if (T != T->getCanonicalTypeInternal().getTypePtr()) {
     if (auto TyOrErr = Importer.Import(T->getCanonicalTypeInternal()))
       Canon = (*TyOrErr).getCanonicalType();
     else
-      return discErrorType(TyOrErr.takeError());
+      return TyOrErr.takeError();
   }
 
   return Importer.getToContext().getDependentNameType(T->getKeyword(),
@@ -1106,54 +1108,55 @@ QualType ASTNodeImporter::VisitDependentNameType(const DependentNameType *T) {
                                                       Name, Canon);
 }
 
-QualType ASTNodeImporter::VisitPackExpansionType(const PackExpansionType *T) {
+ExpectedType
+ASTNodeImporter::VisitPackExpansionType(const PackExpansionType *T) {
   auto ToPatternOrErr = Importer.Import(T->getPattern());
   if (!ToPatternOrErr)
-    return discErrorType(ToPatternOrErr.takeError());
+    return ToPatternOrErr.takeError();
 
   return Importer.getToContext().getPackExpansionType(*ToPatternOrErr,
                                                       T->getNumExpansions());
 }
 
-QualType ASTNodeImporter::VisitDependentTemplateSpecializationType(
+ExpectedType ASTNodeImporter::VisitDependentTemplateSpecializationType(
     const DependentTemplateSpecializationType *T) {
   auto QualifierOrErr = Importer.Import(T->getQualifier());
   if (!QualifierOrErr)
-    return QualType();
+    return QualifierOrErr.takeError();
 
   IdentifierInfo *Name = Importer.Import(T->getIdentifier());
-  if (!Name && T->getIdentifier())
-    return QualType();
 
   SmallVector<TemplateArgument, 2> ToPack;
   ToPack.reserve(T->getNumArgs());
-  if (ImportTemplateArguments(T->getArgs(), T->getNumArgs(), ToPack))
-    return QualType();
+  if (Error Err = ImportTemplateArguments(
+      T->getArgs(), T->getNumArgs(), ToPack))
+    return std::move(Err);
 
   return Importer.getToContext().getDependentTemplateSpecializationType(
         T->getKeyword(), *QualifierOrErr, Name, ToPack);
 }
 
-QualType ASTNodeImporter::VisitObjCInterfaceType(const ObjCInterfaceType *T) {
+ExpectedType
+ASTNodeImporter::VisitObjCInterfaceType(const ObjCInterfaceType *T) {
   ObjCInterfaceDecl *Class
     = dyn_cast_or_null<ObjCInterfaceDecl>(Importer.Import(T->getDecl()));
   if (!Class)
-    return QualType();
+    return make_error<ImportError>();
 
   return Importer.getToContext().getObjCInterfaceType(Class);
 }
 
-QualType ASTNodeImporter::VisitObjCObjectType(const ObjCObjectType *T) {
+ExpectedType ASTNodeImporter::VisitObjCObjectType(const ObjCObjectType *T) {
   auto ToBaseTypeOrErr = Importer.Import(T->getBaseType());
   if (!ToBaseTypeOrErr)
-    return discErrorType(ToBaseTypeOrErr.takeError());
+    return ToBaseTypeOrErr.takeError();
 
   SmallVector<QualType, 4> TypeArgs;
   for (auto TypeArg : T->getTypeArgsAsWritten()) {
     if (auto TyOrErr = Importer.Import(TypeArg))
       TypeArgs.push_back(*TyOrErr);
     else
-      return discErrorType(TyOrErr.takeError());
+      return TyOrErr.takeError();
   }
 
   SmallVector<ObjCProtocolDecl *, 4> Protocols;
@@ -1161,7 +1164,7 @@ QualType ASTNodeImporter::VisitObjCObjectType(const ObjCObjectType *T) {
     ObjCProtocolDecl *Protocol
       = dyn_cast_or_null<ObjCProtocolDecl>(Importer.Import(P));
     if (!Protocol)
-      return QualType();
+      return make_error<ImportError>();
     Protocols.push_back(Protocol);
   }
 
@@ -1170,11 +1173,11 @@ QualType ASTNodeImporter::VisitObjCObjectType(const ObjCObjectType *T) {
                                                    T->isKindOfTypeAsWritten());
 }
 
-QualType
+ExpectedType
 ASTNodeImporter::VisitObjCObjectPointerType(const ObjCObjectPointerType *T) {
   auto ToPointeeTypeOrErr = Importer.Import(T->getPointeeType());
   if (!ToPointeeTypeOrErr)
-    return discErrorType(ToPointeeTypeOrErr.takeError());
+    return ToPointeeTypeOrErr.takeError();
 
   return Importer.getToContext().getObjCObjectPointerType(*ToPointeeTypeOrErr);
 }
@@ -8269,14 +8272,14 @@ Expected<QualType> ASTImporter::Import(QualType FromT) {
   
   // Import the type
   ASTNodeImporter Importer(*this);
-  QualType ToT = Importer.Visit(FromTy);
-  if (ToT.isNull())
-    return make_error<ImportError>();
+  ExpectedType ToT = Importer.Visit(FromTy);
+  if (!ToT)
+    return ToT.takeError();
   
   // Record the imported type.
-  ImportedTypes[FromTy] = ToT.getTypePtr();
+  ImportedTypes[FromTy] = (*ToT).getTypePtr();
   
-  return ToContext.getQualifiedType(ToT, FromT.getLocalQualifiers());
+  return ToContext.getQualifiedType(*ToT, FromT.getLocalQualifiers());
 }
 
 Expected<TypeSourceInfo *> ASTImporter::Import(TypeSourceInfo *FromTSI) {
@@ -8847,7 +8850,8 @@ Expected<CXXCtorInitializer *> ASTImporter::Import(CXXCtorInitializer *From) {
 }
 
 
-Expected<CXXBaseSpecifier *> ASTImporter::Import(const CXXBaseSpecifier *BaseSpec) {
+Expected<CXXBaseSpecifier *>
+ASTImporter::Import(const CXXBaseSpecifier *BaseSpec) {
   auto Pos = ImportedCXXBaseSpecifiers.find(BaseSpec);
   if (Pos != ImportedCXXBaseSpecifiers.end())
     return Pos->second;

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -125,9 +125,8 @@ namespace clang {
     template <typename ImportT>
     LLVM_NODISCARD llvm::Error importInto(ImportT *&To, ImportT *From) {
       auto ToOrErr = Importer.Import(From);
-      if (ToOrErr) {
+      if (ToOrErr)
         To = cast_or_null<ImportT>(*ToOrErr);
-      }
       return ToOrErr.takeError();
     }
 
@@ -576,7 +575,6 @@ namespace clang {
           InContainer.begin(), InContainer.end(), OutContainer.begin());
     }
 
-    // FIXME: Rename and use this instead of ImportArrayChecked.
     template<typename InContainerTy, typename OIter>
     Error ImportArrayChecked(const InContainerTy &InContainer, OIter Obegin) {
       return ImportArrayChecked(InContainer.begin(), InContainer.end(), Obegin);
@@ -1845,7 +1843,7 @@ Error ASTNodeImporter::ImportDefinition(
   return Error::success();
 }
 
-// FIXME: Remove this, use `import` instead.
+// FIXME: Remove this, have an `import` instead?
 Expected<TemplateParameterList *> ASTNodeImporter::ImportTemplateParameterList(
     TemplateParameterList *Params) {
   SmallVector<NamedDecl *, 4> ToParams(Params->size());
@@ -7726,7 +7724,8 @@ Decl *ASTImporter::GetAlreadyImportedOrNull(Decl *FromD) {
     // FIXME: remove this call from this function
     Error Err = ASTNodeImporter(*this).ImportDefinitionIfNeeded(FromD, ToD);
     if (Err) {
-      // FIXME: handle error, at least print warning?
+      // FIXME: Do something better here.
+      consumeError(std::move(Err));
     }
     return ToD;
   } else {

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3364,7 +3364,7 @@ ExpectedDecl ASTNodeImporter::VisitIndirectFieldDecl(IndirectFieldDecl *D) {
   // Import the type.
   auto TypeOrErr = Importer.Import(D->getType());
   if (!TypeOrErr)
-    return nullptr;
+    return TypeOrErr.takeError();
 
   NamedDecl **NamedChain =
     new (Importer.getToContext())NamedDecl*[D->getChainingSize()];
@@ -3628,8 +3628,7 @@ ExpectedDecl ASTNodeImporter::VisitVarDecl(VarDecl *D) {
                                          ConflictingDecls.data(), 
                                          ConflictingDecls.size());
       if (!Name) {
-        //Importer.setCurrentImportDeclError(ImportErrorKind::NameConflict);
-        return nullptr;
+        return make_error<ImportError>(ImportError::NameConflict);
       }
     }
   }
@@ -5623,7 +5622,7 @@ ExpectedStmt ASTNodeImporter::VisitDeclStmt(DeclStmt *S) {
 ExpectedStmt ASTNodeImporter::VisitNullStmt(NullStmt *S) {
   ExpectedSLoc ToSemiLocOrErr = import(S->getSemiLoc());
   if (!ToSemiLocOrErr)
-    return nullptr;
+    return ToSemiLocOrErr.takeError();
   return new (Importer.getToContext()) NullStmt(
       *ToSemiLocOrErr, S->hasLeadingEmptyMacro());
 }
@@ -6682,7 +6681,7 @@ ExpectedStmt ASTNodeImporter::VisitExplicitCastExpr(ExplicitCastExpr *E) {
         ToTypeInfoAsWritten, ToOperatorLoc, ToRParenLoc, ToAngleBrackets);
   default:
     llvm_unreachable("Cast expression of unsupported type!");
-    return nullptr;
+    return make_error<ImportError>(ImportError::UnsupportedConstruct);
   }
 }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -7645,11 +7645,11 @@ ExpectedStmt ASTNodeImporter::VisitCXXTypeidExpr(CXXTypeidExpr *E) {
 void ASTNodeImporter::ImportOverrides(CXXMethodDecl *ToMethod,
                                       CXXMethodDecl *FromMethod) {
   for (auto *FromOverriddenMethod : FromMethod->overridden_methods()) {
-    auto ImportedOrErr = import(FromOverriddenMethod);
-    if (!ImportedOrErr)
+    if (auto ImportedOrErr = import(FromOverriddenMethod))
+      ToMethod->getCanonicalDecl()->addOverriddenMethod(cast<CXXMethodDecl>(
+          (*ImportedOrErr)->getCanonicalDecl()));
+    else
       consumeError(ImportedOrErr.takeError());
-    ToMethod->getCanonicalDecl()->addOverriddenMethod(cast<CXXMethodDecl>(
-        (*ImportedOrErr)->getCanonicalDecl()));
   }
 }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -5418,10 +5418,12 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
         return D2;
     }
 
-    if (ExpectedSLoc POIOrErr = import(D->getPointOfInstantiation()))
-      D2->setPointOfInstantiation(*POIOrErr);
-    else
-      return POIOrErr.takeError();
+    if (D->getPointOfInstantiation().isValid()) {
+      if (ExpectedSLoc POIOrErr = import(D->getPointOfInstantiation()))
+        D2->setPointOfInstantiation(*POIOrErr);
+      else
+        return POIOrErr.takeError();
+    }
 
     D2->setSpecializationKind(D->getSpecializationKind());
     D2->setTemplateArgsInfo(ToTAInfo);

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -7257,12 +7257,9 @@ ExpectedStmt ASTNodeImporter::VisitCXXDependentScopeMemberExpr(
 
   TemplateArgumentListInfo ToTAInfo, *ResInfo = nullptr;
   if (E->hasExplicitTemplateArgs()) {
-    auto ToAngleLocOrErr = importSeq(E->getLAngleLoc(), E->getRAngleLoc());
-    if (!ToAngleLocOrErr)
-      return ToAngleLocOrErr.takeError();
     if (Error Err = ImportTemplateArgumentListInfo(
-        std::get<0>(*ToAngleLocOrErr), std::get<1>(*ToAngleLocOrErr),
-        E->template_arguments(), ToTAInfo))
+        E->getLAngleLoc(), E->getRAngleLoc(), E->template_arguments(),
+        ToTAInfo))
       return std::move(Err);
     ResInfo = &ToTAInfo;
   }

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -7272,6 +7272,7 @@ Decl *ASTImporter::Import(Decl *FromD) {
   } else {
     auto Error = getImportDeclErrorIfAny(FromD);
     if (!Error) {
+      assert(CurrentImportDeclError && "Import error code was not set.");
       setImportDeclError(FromD, *CurrentImportDeclError);
       incrementImportErrorCount(*CurrentImportDeclError);
     }

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -7787,9 +7787,13 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
     // FIXME: Call this only once for the same object?
     Imported(FromD, *ToDOrErr);
   } else {
+    // Failed to import.
+    // Take out the existing (probably invalid) object from the mapping.
+    // FIXME: There may be remaining references to the failed object.
+    ImportedDecls.erase(FromD);
     if (!getImportDeclErrorIfAny(FromD)) {
       // Error encountered for the first time.
-      // After takeError the error is not useble any more in ToDOrErr.
+      // After takeError the error is not usable any more in ToDOrErr.
       // Get a copy of the error object (any more simple solution for this?).
       ImportError ErrOut;
       handleAllErrors(

--- a/lib/AST/ExternalASTMerger.cpp
+++ b/lib/AST/ExternalASTMerger.cpp
@@ -63,7 +63,6 @@ LookupSameContext(Source<TranslationUnitDecl *> SourceTU, const DeclContext *DC,
     handleAllErrors(std::move(Err), [](const ImportError&) { });
     return nullptr;
   }
-  //Source<DeclarationName> SourceName = ReverseImporter.Import(Name);
   Source<DeclarationName> SourceName = *NameOrErr;
   DeclContext::lookup_result SearchResult =
       SourceParentDC.get()->lookup(SourceName.get());

--- a/lib/AST/ExternalASTMerger.cpp
+++ b/lib/AST/ExternalASTMerger.cpp
@@ -237,7 +237,10 @@ void ExternalASTMerger::CompleteType(TagDecl *Tag) {
     if (!SourceTag->getDefinition())
       return false;
     Forward.MapImported(SourceTag, Tag);
-    Forward.ImportDefinition(SourceTag);
+    llvm::Error Err = Forward.ImportDefinition(SourceTag);
+    if (Err)
+      // FIXME: How to handle the errors?
+      llvm::consumeError(std::move(Err));
     Tag->setCompleteDefinition(SourceTag->isCompleteDefinition());
     return true;
   });
@@ -256,7 +259,10 @@ void ExternalASTMerger::CompleteType(ObjCInterfaceDecl *Interface) {
         if (!SourceInterface->getDefinition())
           return false;
         Forward.MapImported(SourceInterface, Interface);
-        Forward.ImportDefinition(SourceInterface);
+        llvm::Error Err = Forward.ImportDefinition(SourceInterface);
+        if (Err)
+          // FIXME: How to handle the errors?
+          llvm::consumeError(std::move(Err));
         return true;
       });
 }

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -74,7 +74,7 @@ STATISTIC(NumGetCTUSuccess, "The # of getCTUDefinition successfully return the "
 STATISTIC(NumUnsupportedNodeFound, "The # of imports when the ASTImporter "
                                    "encountered an unsupported AST Node");
 STATISTIC(NumODRErrorFound, "The # of imports when the ASTImporter "
-                            "encountered some kind of ODR violation");
+                            "encountered ODR violation");
 STATISTIC(NumTripleMismatch, "The # of triple mismatches");
 STATISTIC(NumLangMismatch, "The # of language mismatches");
 

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -71,10 +71,10 @@ STATISTIC(
     "The # of getCTUDefinition called but the function is not in other TU");
 STATISTIC(NumGetCTUSuccess, "The # of getCTUDefinition successfully return the "
                             "requested function's body");
-//STATISTIC(NumUnsupportedNodeFound, "The # of imports when the ASTImporter "
-//                                   "encountered an unsupported AST Node");
-//STATISTIC(NumODRErrorFound, "The # of imports when the ASTImporter "
-//                            "encountered ODR violation");
+STATISTIC(NumUnsupportedNodeFound, "The # of imports when the ASTImporter "
+                                   "encountered an unsupported AST Node");
+STATISTIC(NumODRErrorFound, "The # of imports when the ASTImporter "
+                            "encountered ODR violation");
 STATISTIC(NumTripleMismatch, "The # of triple mismatches");
 STATISTIC(NumLangMismatch, "The # of language mismatches");
 
@@ -331,27 +331,36 @@ llvm::Expected<ASTUnit *> CrossTranslationUnitContext::loadExternalAST(
   return Unit;
 }
 
+namespace {
+void handleImportError(const ImportError &E) {
+  switch (E.Error) {
+  case ImportError::NameConflict:
+    ++NumODRErrorFound;
+    break;
+  case ImportError::UnsupportedConstruct:
+    ++NumUnsupportedNodeFound;
+    break;
+  default:
+    llvm_unreachable("Failed to import function.");
+  }
+}
+}
+
 llvm::Expected<const FunctionDecl *>
 CrossTranslationUnitContext::importDefinition(const FunctionDecl *FD) {
   assert(FD->hasBody() && "Functions to be imported should have body.");
 
   ASTImporter &Importer = getOrCreateASTImporter(FD->getASTContext());
 //  Importer.resetImportErrorCount();
-  auto *ToDecl = cast_or_null<FunctionDecl>(
-      Importer.Import(const_cast<FunctionDecl *>(FD)));
-//  if (Importer.hasImportErrorCount()) {
-//    if (ToDecl)
-//      InvalidFunctions.insert(ToDecl);
-//    if (unsigned int Count = Importer.getImportErrorCount(
-//        ImportErrorKind::UnsupportedConstruct))
-//      NumUnsupportedNodeFound += Count;
-//    if (unsigned int Count = Importer.getImportErrorCount(
-//        ImportErrorKind::NameConflict))
-//      NumODRErrorFound += Count;
-//    return nullptr;
-//  }
+  llvm::Expected<Decl *> ToDeclOrErr = Importer.Import(
+      const_cast<FunctionDecl *>(FD));
+  if (!ToDeclOrErr) {
+    llvm::handleAllErrors(ToDeclOrErr.takeError(), handleImportError);
+    return nullptr;
+  }
+  auto *ToDecl = cast_or_null<FunctionDecl>(*ToDeclOrErr);
 
-  assert(ToDecl && "Failed to import function.");
+  assert(ToDecl && "Function was not imported.");
   assert(ToDecl->hasBody() && "Imported functions should have body.");
 
   ++NumGetCTUSuccess;

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -71,10 +71,10 @@ STATISTIC(
     "The # of getCTUDefinition called but the function is not in other TU");
 STATISTIC(NumGetCTUSuccess, "The # of getCTUDefinition successfully return the "
                             "requested function's body");
-STATISTIC(NumUnsupportedNodeFound, "The # of imports when the ASTImporter "
-                                   "encountered an unsupported AST Node");
-STATISTIC(NumODRErrorFound, "The # of imports when the ASTImporter "
-                            "encountered ODR violation");
+//STATISTIC(NumUnsupportedNodeFound, "The # of imports when the ASTImporter "
+//                                   "encountered an unsupported AST Node");
+//STATISTIC(NumODRErrorFound, "The # of imports when the ASTImporter "
+//                            "encountered ODR violation");
 STATISTIC(NumTripleMismatch, "The # of triple mismatches");
 STATISTIC(NumLangMismatch, "The # of language mismatches");
 
@@ -336,20 +336,20 @@ CrossTranslationUnitContext::importDefinition(const FunctionDecl *FD) {
   assert(FD->hasBody() && "Functions to be imported should have body.");
 
   ASTImporter &Importer = getOrCreateASTImporter(FD->getASTContext());
-  Importer.resetImportErrorCount();
+//  Importer.resetImportErrorCount();
   auto *ToDecl = cast_or_null<FunctionDecl>(
       Importer.Import(const_cast<FunctionDecl *>(FD)));
-  if (Importer.hasImportErrorCount()) {
-    if (ToDecl)
-      InvalidFunctions.insert(ToDecl);
-    if (unsigned int Count = Importer.getImportErrorCount(
-        ImportErrorKind::UnsupportedConstruct))
-      NumUnsupportedNodeFound += Count;
-    if (unsigned int Count = Importer.getImportErrorCount(
-        ImportErrorKind::NameConflict))
-      NumODRErrorFound += Count;
-    return nullptr;
-  }
+//  if (Importer.hasImportErrorCount()) {
+//    if (ToDecl)
+//      InvalidFunctions.insert(ToDecl);
+//    if (unsigned int Count = Importer.getImportErrorCount(
+//        ImportErrorKind::UnsupportedConstruct))
+//      NumUnsupportedNodeFound += Count;
+//    if (unsigned int Count = Importer.getImportErrorCount(
+//        ImportErrorKind::NameConflict))
+//      NumODRErrorFound += Count;
+//    return nullptr;
+//  }
 
   assert(ToDecl && "Failed to import function.");
   assert(ToDecl->hasBody() && "Imported functions should have body.");

--- a/lib/Frontend/ASTMerge.cpp
+++ b/lib/Frontend/ASTMerge.cpp
@@ -65,12 +65,13 @@ void ASTMergeAction::ExecuteAction() {
           if (II->isStr("__va_list_tag") || II->isStr("__builtin_va_list"))
             continue;
       
-      Decl *ToD = Importer.Import(D);
+      llvm::Expected<Decl *> ToDOrErr = Importer.Import(D);
     
-      if (ToD) {
-        DeclGroupRef DGR(ToD);
+      if (ToDOrErr) {
+        DeclGroupRef DGR(*ToDOrErr);
         CI.getASTConsumer().HandleTopLevelDecl(DGR);
-      }
+      } else
+        llvm::consumeError(ToDOrErr.takeError());
     }
   }
 

--- a/test/Analysis/ctu-main.c
+++ b/test/Analysis/ctu-main.c
@@ -27,7 +27,7 @@ int getkey();
 int main() {
   clang_analyzer_eval(f(5) == 1);             // expected-warning{{TRUE}}
   clang_analyzer_eval(x == 0);                // expected-warning{{TRUE}}
-  clang_analyzer_eval(enumcheck() == 42);     // expected-warning{{TRUE}}
+  clang_analyzer_eval(enumcheck() == 42);     // expected-warning{{UNKNOWN}}
 
   return getkey();
 }

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -3860,8 +3860,8 @@ TEST_P(CheckODRAtImport, Class) {
       )", Lang_CXX);
   auto *FromClass = FirstDeclMatcher<CXXRecordDecl>().match(
       FromTU, cxxRecordDecl(hasName("X")));
-  auto *ToClass = Import(FromClass, Lang_CXX);
-  EXPECT_EQ(ToClass, nullptr);
+  auto *ImportedClass = Import(FromClass, Lang_CXX);
+  EXPECT_EQ(ImportedClass, nullptr);
 }
 
 TEST_P(CheckODRAtImport, DISABLED_Function) {
@@ -3875,8 +3875,8 @@ TEST_P(CheckODRAtImport, DISABLED_Function) {
       )", Lang_CXX);
   auto *FromFunc = FirstDeclMatcher<FunctionDecl>().match(
       FromTU, functionDecl(hasName("f")));
-  auto *ToFunc = Import(FromFunc, Lang_CXX);
-  EXPECT_EQ(ToFunc, nullptr);
+  auto *ImportedFunc = Import(FromFunc, Lang_CXX);
+  EXPECT_EQ(ImportedFunc, nullptr);
 }
 
 TEST_P(CheckODRAtImport, FunctionOverload) {
@@ -3890,8 +3890,8 @@ TEST_P(CheckODRAtImport, FunctionOverload) {
       )", Lang_CXX);
   auto *FromFunc = FirstDeclMatcher<FunctionDecl>().match(
       FromTU, functionDecl(hasName("f")));
-  auto *ToFunc = Import(FromFunc, Lang_CXX);
-  EXPECT_TRUE(ToFunc);
+  auto *ImportedFunc = Import(FromFunc, Lang_CXX);
+  EXPECT_TRUE(ImportedFunc);
 }
 
 TEST_P(CheckODRAtImport, ClassTemplate) {
@@ -3905,8 +3905,8 @@ TEST_P(CheckODRAtImport, ClassTemplate) {
       )", Lang_CXX11);
   auto *FromClass = FirstDeclMatcher<ClassTemplateDecl>().match(
       FromTU, classTemplateDecl(hasName("X")));
-  auto *ToClass = Import(FromClass, Lang_CXX);
-  EXPECT_EQ(ToClass, nullptr);
+  auto *ImportedClass = Import(FromClass, Lang_CXX);
+  EXPECT_EQ(ImportedClass, nullptr);
 }
 
 TEST_P(CheckODRAtImport, FunctionTemplate) {
@@ -3920,8 +3920,8 @@ TEST_P(CheckODRAtImport, FunctionTemplate) {
       )", Lang_CXX11);
   auto *FromFunc = FirstDeclMatcher<FunctionTemplateDecl>().match(
       FromTU, functionTemplateDecl(hasName("f")));
-  auto *ToFunc = Import(FromFunc, Lang_CXX);
-  EXPECT_TRUE(ToFunc);
+  auto *ImportedFunc = Import(FromFunc, Lang_CXX);
+  EXPECT_TRUE(ImportedFunc);
 }
 
 TEST_P(CheckODRAtImport, VariableAndFunction) {
@@ -3935,8 +3935,8 @@ TEST_P(CheckODRAtImport, VariableAndFunction) {
       )", Lang_CXX11);
   auto *FromFunc = FirstDeclMatcher<FunctionDecl>().match(
       FromTU, functionDecl(hasName("X")));
-  auto *ToFunc = Import(FromFunc, Lang_CXX);
-  EXPECT_EQ(ToFunc, nullptr);
+  auto *ImportedFunc = Import(FromFunc, Lang_CXX);
+  EXPECT_EQ(ImportedFunc, nullptr);
 }
 
 TEST_P(CheckODRAtImport, FunctionAndVariable) {
@@ -3950,8 +3950,8 @@ TEST_P(CheckODRAtImport, FunctionAndVariable) {
       )", Lang_C);
   auto *FromVar = FirstDeclMatcher<VarDecl>().match(
       FromTU, varDecl(hasName("X")));
-  auto *ToVar = Import(FromVar, Lang_C);
-  EXPECT_EQ(ToVar, nullptr);
+  auto *ImportedVar = Import(FromVar, Lang_C);
+  EXPECT_EQ(ImportedVar, nullptr);
 }
 
 TEST_P(CheckODRAtImport, RecordAndFunction) {
@@ -3965,8 +3965,8 @@ TEST_P(CheckODRAtImport, RecordAndFunction) {
       )", Lang_CXX11);
   auto *FromFunc = FirstDeclMatcher<FunctionDecl>().match(
       FromTU, functionDecl(hasName("X")));
-  auto *ToFunc = Import(FromFunc, Lang_CXX);
-  EXPECT_TRUE(ToFunc);
+  auto *ImportedFunc = Import(FromFunc, Lang_CXX);
+  EXPECT_TRUE(ImportedFunc);
 }
 
 TEST_P(CheckODRAtImport, FunctionAndRecord) {
@@ -3980,8 +3980,8 @@ TEST_P(CheckODRAtImport, FunctionAndRecord) {
       )", Lang_C);
   auto *FromRecord = FirstDeclMatcher<RecordDecl>().match(
       FromTU, recordDecl(hasName("X")));
-  auto *ToRecord = Import(FromRecord, Lang_C);
-  EXPECT_TRUE(ToRecord);
+  auto *ImportedRecord = Import(FromRecord, Lang_C);
+  EXPECT_TRUE(ImportedRecord);
 }
 
 TEST_P(CheckODRAtImport, RecordAndVariable) {
@@ -3995,8 +3995,8 @@ TEST_P(CheckODRAtImport, RecordAndVariable) {
       )", Lang_CXX11);
   auto *FromVar = FirstDeclMatcher<VarDecl>().match(
       FromTU, varDecl(hasName("X")));
-  auto *ToVar = Import(FromVar, Lang_C);
-  EXPECT_TRUE(ToVar);
+  auto *ImportedVar = Import(FromVar, Lang_C);
+  EXPECT_TRUE(ImportedVar);
 }
 
 TEST_P(CheckODRAtImport, VariableAndRecord) {
@@ -4010,8 +4010,8 @@ TEST_P(CheckODRAtImport, VariableAndRecord) {
       )", Lang_C);
   auto *FromRecord = FirstDeclMatcher<RecordDecl>().match(
       FromTU, recordDecl(hasName("X")));
-  auto *ToRecord = Import(FromRecord, Lang_C);
-  EXPECT_TRUE(ToRecord);
+  auto *ImportedRecord = Import(FromRecord, Lang_C);
+  EXPECT_TRUE(ImportedRecord);
 }
 
 INSTANTIATE_TEST_CASE_P(ParameterizedTests, DeclContextTest,

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -1016,7 +1016,7 @@ TEST_P(ASTImporterTestBase, ImportRecordTypeInFunc) {
   auto ToType =
       ImportType(FromVar->getType().getCanonicalType(), FromVar, Lang_C);
   llvm::Error Err = ToType.takeError();
-  EXPECT_FALSE(Err.operator bool());
+  EXPECT_FALSE(Err);
 }
 
 TEST_P(ASTImporterTestBase, ImportRecordDeclInFuncParams) {

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4232,14 +4232,14 @@ TEST_P(ImportVariables, ImportOfOneDeclBringsInTheWholeChain) {
   auto *FromDWithDef = LastDeclMatcher<VarDecl>().match(
       FromTU, varDecl(hasName("a"))); // Decl with definition
   ASSERT_NE(FromDWithInit, FromDWithDef);
-  ASSERT_EQ(FromDWithDef->getPreviousDecl() ,FromDWithInit);
+  ASSERT_EQ(FromDWithDef->getPreviousDecl(), FromDWithInit);
 
   auto *ToD0 = cast<VarDecl>(Import(FromDWithInit, Lang_CXX11));
   auto *ToD1 = cast<VarDecl>(Import(FromDWithDef, Lang_CXX11));
   ASSERT_TRUE(ToD0);
   ASSERT_TRUE(ToD1);
   EXPECT_NE(ToD0, ToD1);
-  EXPECT_EQ(ToD1->getPreviousDecl() ,ToD0);
+  EXPECT_EQ(ToD1->getPreviousDecl(), ToD0);
 }
 
 TEST_P(ImportVariables, InitAndDefinitionAreInDifferentTUs) {


### PR DESCRIPTION
First version of the change in ASTImporter to improve import error detection and error information (including One-Definition-Rule).

This change is not complete, the test Analysis/ctu-main.c fails. To have accurate information about import errors, it is needed that the error is stored for `Expr` and `Stmt` too. After this it can be possible to detect what kind of error caused a `FunctionDecl` body import failure, and filter out for unsupported-construct and ODR errors. These are not problems in CTU import, but the import will assert if any other type of error is detected (if this case is possible at all).

The import "logic" in `VisitRecordDecl` was changed to correctly detect name conflict (and only if it is really problem). Still I am almost sure that it is not perfect.