### PR TITLE
Eliminate race condition in CTU lit tests

### DIFF
--- a/test/Analysis/ctu-different-triples.c
+++ b/test/Analysis/ctu-different-triples.c
@@ -1,7 +1,8 @@
-// RUN: mkdir -p %T/ctudir3
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir3/ctu-other.c.ast %S/Inputs/ctu-other.c
-// RUN: cp %S/Inputs/externalFnMap2.txt %T/ctudir3/externalFnMap.txt
-// RUN: %clang_cc1 -triple powerpc64-montavista-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir3 -verify %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: mkdir -p %t/ctudir3
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir3/ctu-other.c.ast %S/Inputs/ctu-other.c
+// RUN: cp %S/Inputs/externalFnMap2.txt %t/ctudir3/externalFnMap.txt
+// RUN: %clang_cc1 -triple powerpc64-montavista-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir3 -verify %s
 
 // We expect an error in this file, but without a location.
 // expected-error-re@./ctu-different-triples.c:*{{imported AST from {{.*}} had been generated for a different target, current: powerpc64-montavista-linux-gnu, imported: x86_64-pc-linux-gnu}}

--- a/test/Analysis/ctu-main.c
+++ b/test/Analysis/ctu-main.c
@@ -1,7 +1,8 @@
-// RUN: mkdir -p %T/ctudir2
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir2/ctu-other.c.ast %S/Inputs/ctu-other.c
-// RUN: cp %S/Inputs/externalFnMap2.txt %T/ctudir2/externalFnMap.txt
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection  -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir2 -verify %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: mkdir -p %t/ctudir2
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir2/ctu-other.c.ast %S/Inputs/ctu-other.c
+// RUN: cp %S/Inputs/externalFnMap2.txt %t/ctudir2/externalFnMap.txt
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection  -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir2 -verify %s
 
 void clang_analyzer_eval(int);
 

--- a/test/Analysis/ctu-main.cpp
+++ b/test/Analysis/ctu-main.cpp
@@ -1,9 +1,10 @@
-// RUN: mkdir -p %T/ctudir
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir/ctu-other.cpp.ast %S/Inputs/ctu-other.cpp
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir/ctu-chain.cpp.ast %S/Inputs/ctu-chain.cpp
-// RUN: cp %S/Inputs/externalFnMap.txt %T/ctudir/
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir -verify %s
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir -std=c++11 -analyzer-display-ctu-progress 2>&1 %s | FileCheck %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: mkdir -p %t/ctudir
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir/ctu-other.cpp.ast %S/Inputs/ctu-other.cpp
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir/ctu-chain.cpp.ast %S/Inputs/ctu-chain.cpp
+// RUN: cp %S/Inputs/externalFnMap.txt %t/ctudir/
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir -verify %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir -std=c++11 -analyzer-display-ctu-progress 2>&1 %s | FileCheck %s
 
 // CHECK: ANALYZE (CTU loaded AST for source file): {{.*}}/ctu-other.cpp
 // CHECK: ANALYZE (CTU loaded AST for source file): {{.*}}/ctu-chain.cpp

--- a/test/Analysis/ctu-unknown-parts-in-triples.c
+++ b/test/Analysis/ctu-unknown-parts-in-triples.c
@@ -1,10 +1,11 @@
 // We do not expect any error when one part of the triple is unknown, but other
 // known parts are equal.
 
-// RUN: mkdir -p %T/ctudir3
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir3/ctu-other.c.ast %S/Inputs/ctu-other.c
-// RUN: cp %S/Inputs/externalFnMap2.txt %T/ctudir3/externalFnMap.txt
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection  -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir3 -verify %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: mkdir -p %t/ctudir3
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir3/ctu-other.c.ast %S/Inputs/ctu-other.c
+// RUN: cp %S/Inputs/externalFnMap2.txt %t/ctudir3/externalFnMap.txt
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection  -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir3 -verify %s
 
 // expected-no-diagnostics
 

--- a/test/Analysis/ctu-va_list.cpp
+++ b/test/Analysis/ctu-va_list.cpp
@@ -1,45 +1,46 @@
-// RUN: mkdir -p %T/ctudir4
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple x86_64-pc-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: mkdir -p %t/ctudir4
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple x86_64-pc-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: %clang_cc1 -triple powerpc-montavista-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple powerpc-montavista-pc-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple powerpc-montavista-pc-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: %clang_cc1 -triple powerpc-montavista-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple powerpc-montavista-pc-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple powerpc-montavista-pc-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: %clang_cc1 -triple powerpc64-montavista-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple powerpc64-montavista-pc-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple powerpc64-montavista-pc-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: %clang_cc1 -triple powerpc64-montavista-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple powerpc64-montavista-pc-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple powerpc64-montavista-pc-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: %clang_cc1 -triple arm64-linux-android -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple arm64-linux-android -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple arm64-linux-android -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: %clang_cc1 -triple arm64-linux-android -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple arm64-linux-android -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple arm64-linux-android -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple le32-unknown-nacl -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple le32-unknown-nacl -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: %clang_cc1 -triple arm-linux-androideabi -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple arm-linux-androideabi -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple arm-linux-androideabi -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: %clang_cc1 -triple arm-linux-androideabi -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple arm-linux-androideabi -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple arm-linux-androideabi -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: mkdir -p %T/ctudir4
-// RUN: %clang_cc1 -triple systemz-unknown-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple systemz-unknown-linux-gnu -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple systemz-unknown-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: mkdir -p %t/ctudir4
+// RUN: %clang_cc1 -triple systemz-unknown-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple systemz-unknown-linux-gnu -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple systemz-unknown-linux-gnu -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
-// RUN: mkdir -p %T/ctudir4
-// RUN: %clang_cc1 -triple lanai-unknown-unknown -emit-pch -o %T/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
-// RUN: %clang_cc1 -triple lanai-unknown-unknown -emit-pch -o %T/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
-// RUN: cp %S/Inputs/externalFnMap_va_list.txt %T/ctudir4/externalFnMap.txt
-// RUN: %clang_analyze_cc1 -triple lanai-unknown-unknown -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir4 -verify %s
+// RUN: mkdir -p %t/ctudir4
+// RUN: %clang_cc1 -triple lanai-unknown-unknown -emit-pch -o %t/ctudir4/ctu-va_list-first.c.ast %S/Inputs/ctu-va_list-first.c
+// RUN: %clang_cc1 -triple lanai-unknown-unknown -emit-pch -o %t/ctudir4/ctu-va_list-second.cpp.ast %S/Inputs/ctu-va_list-second.cpp
+// RUN: cp %S/Inputs/externalFnMap_va_list.txt %t/ctudir4/externalFnMap.txt
+// RUN: %clang_analyze_cc1 -triple lanai-unknown-unknown -analyzer-checker=core -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t/ctudir4 -verify %s
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
The usage of LLVM lit tests "%T" is dangerous because it may cause race conditions between the individual test cases.

https://llvm.org/docs/TestingGuide.html

> %T
> Directory of %t. Deprecated. Shouldn’t be used, because it can be easily misused and cause race conditions between tests.
>
> Use rm -rf %t && mkdir %t instead if a temporary directory is necessary.
>
> Example: /home/user/llvm.build/test/MC/ELF/Output
