### PR TITLE
Clang and llvm Revision/repository now can be specified as a compilation flag.

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -36,11 +36,31 @@ else()
   # Not producing a VC revision include.
   set(version_inc)
 
-  # Being able to force-set the SVN revision in cases where it isn't available
+  # Being able to force-set the clang and llvm revision in cases where it isn't available
   # is useful for performance tracking, and matches compatibility from autoconf.
   if(SVN_REVISION)
-    set_source_files_properties(Version.cpp
-      PROPERTIES COMPILE_DEFINITIONS "SVN_REVISION=\"${SVN_REVISION}\"")
+	set_property(
+		SOURCE Version.cpp
+		APPEND
+        PROPERTY COMPILE_DEFINITIONS "SVN_REVISION=\"${SVN_REVISION}\"")
+  endif()
+  if(SVN_REPOSITORY)
+	set_property(
+		SOURCE Version.cpp
+		APPEND
+        PROPERTY COMPILE_DEFINITIONS "SVN_REPOSITORY=\"${SVN_REPOSITORY}\"")
+  endif()
+  if(LLVM_REVISION)
+	set_property(
+		SOURCE Version.cpp
+		APPEND
+        PROPERTY COMPILE_DEFINITIONS "LLVM_REVISION=\"${LLVM_REVISION}\"")
+  endif()
+  if(LLVM_REPOSITORY)
+	set_property(
+		SOURCE Version.cpp
+		APPEND
+        PROPERTY COMPILE_DEFINITIONS "LLVM_REPOSITORY=\"${LLVM_REPOSITORY}\"")
   endif()
 endif()
 


### PR DESCRIPTION
Alongside the existing -DSVN_REVISION flag, (which specifies the clang revision
number) now there are three more flag that can be specified when there are
no revision info in the clang/llvm source directory.

-DSVN_REPOSITORY=<url> specifies clang repository.
-DLLVM_REVISION=<revno> specifies llvm revision.
-DLLVM_REPOSITORY=<url> specigies llvm repositiory.
