### PR TITLE
Fix redecl chain of classes and class templates

### DIFF
--- a/.lldb-commit
+++ b/.lldb-commit
@@ -1,1 +1,1 @@
-release_60
+7d6da32

--- a/include/clang/AST/DeclContextInternals.h
+++ b/include/clang/AST/DeclContextInternals.h
@@ -122,6 +122,13 @@ public:
              == Vec.end() && "list still contains decl");
   }
 
+  bool containsInVector(NamedDecl *D) {
+    assert(getAsVector());
+    DeclsTy &Vec = *getAsVector();
+    DeclsTy::iterator I = std::find(Vec.begin(), Vec.end(), D);
+    return I != Vec.end();
+  }
+
   /// \brief Remove any declarations which were imported from an external
   /// AST source.
   void removeExternalDecls() {

--- a/include/clang/ASTMatchers/ASTMatchers.h
+++ b/include/clang/ASTMatchers/ASTMatchers.h
@@ -1081,6 +1081,17 @@ extern const internal::VariadicDynCastAllOfMatcher<Decl, VarDecl> varDecl;
 ///   matches 'm'.
 extern const internal::VariadicDynCastAllOfMatcher<Decl, FieldDecl> fieldDecl;
 
+/// \brief Matches field declarations.
+///
+/// Given
+/// \code
+///   struct X { struct { int a; }; };
+/// \endcode
+/// fieldDecl()
+///   matches 'a'.
+extern const internal::VariadicDynCastAllOfMatcher<Decl, IndirectFieldDecl>
+    indirectFieldDecl;
+
 /// \brief Matches function declarations.
 ///
 /// Example matches f

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2279,11 +2279,9 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
             continue;
         }
 
-        PrevDecl = FoundRecord;
-
-        if (RecordDecl *FoundDef = FoundRecord->getDefinition()) {
-          if (D->isThisDeclarationADefinition() &&
-              IsStructuralMatch(D, FoundDef)) {
+        if (IsStructuralMatch(D, FoundRecord)) {
+          RecordDecl *FoundDef = FoundRecord->getDefinition();
+          if (D->isThisDeclarationADefinition() && FoundDef) {
             // FIXME: Structural equivalence check should check for same
             // user-defined methods.
             Importer.MapImported(D, FoundDef);
@@ -2296,8 +2294,9 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
                 // because implicit methods are created only if they are used.
                 ImportImplicitMethods(DCXX, FoundCXX);
             }
-            return FoundDef;
           }
+          PrevDecl = FoundRecord;
+          break;
         }
       }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2282,7 +2282,7 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         //    struct { struct A *next; } entry0;
         //    struct { struct A *next; } entry1;
         //  };
-        //  struct X { struct { int a; }; struct { int b; }; // anon structs
+        //  struct X { struct { int a; }; struct { int b; }; }; // anon structs
         if (!SearchName)
           if (!IsStructuralMatch(D, FoundRecord, false))
             continue;

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -68,6 +68,8 @@ namespace clang {
       return getCanonicalForwardRedeclChain<FunctionDecl>(FD);
     if (auto *VD = dyn_cast<VarDecl>(D))
       return getCanonicalForwardRedeclChain<VarDecl>(VD);
+    if (auto *TD = dyn_cast<TagDecl>(D))
+      return getCanonicalForwardRedeclChain<TagDecl>(TD);
     llvm_unreachable("Bad declaration kind");
   }
 
@@ -2242,7 +2244,6 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
     IDNS |= Decl::IDNS_Ordinary | Decl::IDNS_TagFriend;
 
   // We may already have a record of the same name; try to find and match it.
-  RecordDecl *AdoptDecl = nullptr;
   RecordDecl *PrevDecl = nullptr;
   if (!DC->isFunctionOrMethod()) {
     SmallVector<NamedDecl *, 4> ConflictingDecls;
@@ -2281,35 +2282,30 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         PrevDecl = FoundRecord;
 
         if (RecordDecl *FoundDef = FoundRecord->getDefinition()) {
-          if ((SearchName && !D->isCompleteDefinition() && !IsFriendTemplate)
-              || (D->isCompleteDefinition() &&
-                  D->isAnonymousStructOrUnion()
-                    == FoundDef->isAnonymousStructOrUnion() &&
-                  IsStructuralMatch(D, FoundDef))) {
-            // The record types structurally match, or the "from" translation
-            // unit only had a forward declaration anyway; call it the same
-            // function.
-            // FIXME: Structural equivalence check should check for same
-            // user-defined methods.
-            Importer.MapImported(D, FoundDef);
-            if (const auto *DCXX = dyn_cast<CXXRecordDecl>(D)) {
-              auto *FoundCXX = dyn_cast<CXXRecordDecl>(FoundDef);
-              assert(FoundCXX && "Record type mismatch");
+          if (D->isThisDeclarationADefinition()) {
+            if ((SearchName && !D->isCompleteDefinition() && !IsFriendTemplate)
+                || (D->isCompleteDefinition() &&
+                    D->isAnonymousStructOrUnion()
+                      == FoundDef->isAnonymousStructOrUnion() &&
+                    IsStructuralMatch(D, FoundDef))) {
+              // FIXME: Structural equivalence check should check for same
+              // user-defined methods.
+              Importer.MapImported(D, FoundDef);
+              if (const auto *DCXX = dyn_cast<CXXRecordDecl>(D)) {
+                auto *FoundCXX = dyn_cast<CXXRecordDecl>(FoundDef);
+                assert(FoundCXX && "Record type mismatch");
 
-              if (D->isCompleteDefinition() && !Importer.isMinimalImport())
-                // FoundDef may not have every implicit method that D has
-                // because implicit methods are created only if they are used.
-                ImportImplicitMethods(DCXX, FoundCXX);
+                if (D->isCompleteDefinition() && !Importer.isMinimalImport())
+                  // FoundDef may not have every implicit method that D has
+                  // because implicit methods are created only if they are used.
+                  ImportImplicitMethods(DCXX, FoundCXX);
+              }
+              return FoundDef;
             }
-            return FoundDef;
           }
         } else if (!D->isCompleteDefinition()) {
-          // We have a forward declaration of this type, so adopt that forward
-          // declaration rather than building a new one.
-            
-          // If one or both can be completed from external storage then try one
-          // last time to complete and compare them before doing this.
-            
+          // We have a forward declaration of this type in the "From" context,
+          // we have to hook that to the redecl chain.
           if (FoundRecord->hasExternalLexicalStorage() &&
               !FoundRecord->isCompleteDefinition())
             FoundRecord->getASTContext().getExternalSource()->CompleteType(FoundRecord);
@@ -2324,8 +2320,6 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
           if (IsFriendTemplate)
             continue;
 
-          AdoptDecl = FoundRecord;
-          continue;
         } else if (!SearchName) {
           continue;
         }
@@ -2342,107 +2336,120 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
   }
   
   // Create the record declaration.
-  RecordDecl *D2 = AdoptDecl;
+  RecordDecl *D2 = nullptr;
   SourceLocation StartLoc = Importer.Import(D->getLocStart());
-  if (!D2) {
-    CXXRecordDecl *D2CXX = nullptr;
-    if (CXXRecordDecl *DCXX = llvm::dyn_cast<CXXRecordDecl>(D)) {
-      if (DCXX->isLambda()) {
-        TypeSourceInfo *TInfo = Importer.Import(DCXX->getLambdaTypeInfo());
-        if (GetImportedOrCreateSpecialDecl(
-                D2CXX, CXXRecordDecl::CreateLambda, D, Importer.getToContext(),
-                DC, TInfo, Loc, DCXX->isDependentLambda(),
-                DCXX->isGenericLambda(), DCXX->getLambdaCaptureDefault()))
-          return D2CXX;
-        Decl *CDecl = Importer.Import(DCXX->getLambdaContextDecl());
-        if (DCXX->getLambdaContextDecl() && !CDecl)
-          return nullptr;
-        D2CXX->setLambdaMangling(DCXX->getLambdaManglingNumber(), CDecl);
-      } else if (DCXX->isInjectedClassName()) {
-        // We have to be careful to do a similar dance to the one in
-        // Sema::ActOnStartCXXMemberDeclarations
-        CXXRecordDecl *const PrevDecl = nullptr;
-        const bool DelayTypeCreation = true;
-        if (GetImportedOrCreateDecl(D2CXX, D, Importer.getToContext(),
-                                    D->getTagKind(), DC, StartLoc, Loc,
-                                    Name.getAsIdentifierInfo(), PrevDecl,
-                                    DelayTypeCreation))
-          return D2CXX;
-        Importer.getToContext().getTypeDeclType(
-            D2CXX, dyn_cast<CXXRecordDecl>(DC));
-      } else {
-        if (GetImportedOrCreateDecl(D2CXX, D, Importer.getToContext(),
-                                    D->getTagKind(), DC, StartLoc, Loc,
-                                    Name.getAsIdentifierInfo(),
-                                    cast_or_null<CXXRecordDecl>(PrevDecl)))
-          return D2CXX;
-      }
-
-      D2 = D2CXX;
-      D2->setAccess(D->getAccess());
-      D2->setLexicalDeclContext(LexicalDC);
-      if (!DCXX->getDescribedClassTemplate() || DCXX->isImplicit())
-        LexicalDC->addDeclInternal(D2);
-
-      if (ClassTemplateDecl *FromDescribed =
-          DCXX->getDescribedClassTemplate()) {
-        ClassTemplateDecl *ToDescribed = cast_or_null<ClassTemplateDecl>(
-              Importer.Import(FromDescribed));
-        if (!ToDescribed)
-          return nullptr;
-        D2CXX->setDescribedClassTemplate(ToDescribed);
-        if (!DCXX->isInjectedClassName() && !IsFriendTemplate) {
-          // In a record describing a template the type should be an
-          // InjectedClassNameType (see Sema::CheckClassTemplate). Update the
-          // previously set type to the correct value here (ToDescribed is not
-          // available at record create).
-          // FIXME: The previous type is cleared but not removed from
-          // ASTContext's internal storage.
-          CXXRecordDecl *Injected = nullptr;
-          for (NamedDecl *Found : D2CXX->noload_lookup(Name)) {
-            auto *Record = dyn_cast<CXXRecordDecl>(Found);
-            if (Record && Record->isInjectedClassName()) {
-              Injected = Record;
-              break;
-            }
-          }
-          D2CXX->setTypeForDecl(nullptr);
-          Importer.getToContext().getInjectedClassNameType(D2CXX,
-              ToDescribed->getInjectedClassNameSpecialization());
-          if (Injected) {
-            Injected->setTypeForDecl(nullptr);
-            Importer.getToContext().getTypeDeclType(Injected, D2CXX);
-          }
-        }
-      } else if (MemberSpecializationInfo *MemberInfo =
-                   DCXX->getMemberSpecializationInfo()) {
-        TemplateSpecializationKind SK =
-            MemberInfo->getTemplateSpecializationKind();
-        CXXRecordDecl *FromInst = DCXX->getInstantiatedFromMemberClass();
-        CXXRecordDecl *ToInst =
-            cast_or_null<CXXRecordDecl>(Importer.Import(FromInst));
-        if (FromInst && !ToInst)
-          return nullptr;
-        D2CXX->setInstantiationOfMemberClass(ToInst, SK);
-        D2CXX->getMemberSpecializationInfo()->setPointOfInstantiation(
-              Importer.Import(MemberInfo->getPointOfInstantiation()));
-      }
-
+  CXXRecordDecl *D2CXX = nullptr;
+  if (CXXRecordDecl *DCXX = llvm::dyn_cast<CXXRecordDecl>(D)) {
+    if (DCXX->isLambda()) {
+      TypeSourceInfo *TInfo = Importer.Import(DCXX->getLambdaTypeInfo());
+      if (GetImportedOrCreateSpecialDecl(
+              D2CXX, CXXRecordDecl::CreateLambda, D, Importer.getToContext(),
+              DC, TInfo, Loc, DCXX->isDependentLambda(),
+              DCXX->isGenericLambda(), DCXX->getLambdaCaptureDefault()))
+        return D2CXX;
+      Decl *CDecl = Importer.Import(DCXX->getLambdaContextDecl());
+      if (DCXX->getLambdaContextDecl() && !CDecl)
+        return nullptr;
+      D2CXX->setLambdaMangling(DCXX->getLambdaManglingNumber(), CDecl);
+    } else if (DCXX->isInjectedClassName()) {
+      // We have to be careful to do a similar dance to the one in
+      // Sema::ActOnStartCXXMemberDeclarations
+      const bool DelayTypeCreation = true;
+      if (GetImportedOrCreateDecl(
+              D2CXX, D, Importer.getToContext(), D->getTagKind(), DC,
+              StartLoc, Loc, Name.getAsIdentifierInfo(),
+              cast_or_null<CXXRecordDecl>(PrevDecl), DelayTypeCreation))
+        return D2CXX;
+      Importer.getToContext().getTypeDeclType(
+          D2CXX, dyn_cast<CXXRecordDecl>(DC));
     } else {
-      if (GetImportedOrCreateDecl(D2, D, Importer.getToContext(),
+      if (GetImportedOrCreateDecl(D2CXX, D, Importer.getToContext(),
                                   D->getTagKind(), DC, StartLoc, Loc,
-                                  Name.getAsIdentifierInfo(), PrevDecl))
-        return D2;
-      D2->setLexicalDeclContext(LexicalDC);
-      LexicalDC->addDeclInternal(D2);
+                                  Name.getAsIdentifierInfo(),
+                                  cast_or_null<CXXRecordDecl>(PrevDecl)))
+        return D2CXX;
     }
 
-    D2->setQualifierInfo(Importer.Import(D->getQualifierLoc()));
-    if (D->isAnonymousStructOrUnion())
-      D2->setAnonymousStructOrUnion(true);
+    D2 = D2CXX;
+    D2->setAccess(D->getAccess());
+    D2->setLexicalDeclContext(LexicalDC);
+
+    if (D->getDeclContext()->containsDeclAndLoad(D))
+      DC->addDeclInternal(D2);
+    if (DC != LexicalDC && D->getLexicalDeclContext()->containsDeclAndLoad(D))
+      LexicalDC->addDeclInternal(D2);
+
+    const bool IsFriend = D->isInIdentifierNamespace(Decl::IDNS_TagFriend);
+    if (LexicalDC != DC && IsFriend) {
+      DC->makeDeclVisibleInContext(D2);
+    }
+
+    if (ClassTemplateDecl *FromDescribed =
+        DCXX->getDescribedClassTemplate()) {
+      ClassTemplateDecl *ToDescribed = cast_or_null<ClassTemplateDecl>(
+            Importer.Import(FromDescribed));
+      if (!ToDescribed)
+        return nullptr;
+      D2CXX->setDescribedClassTemplate(ToDescribed);
+      if (!DCXX->isInjectedClassName() && !IsFriendTemplate) {
+        // In a record describing a template the type should be an
+        // InjectedClassNameType (see Sema::CheckClassTemplate). Update the
+        // previously set type to the correct value here (ToDescribed is not
+        // available at record create).
+        // FIXME: The previous type is cleared but not removed from
+        // ASTContext's internal storage.
+        CXXRecordDecl *Injected = nullptr;
+        for (NamedDecl *Found : D2CXX->noload_lookup(Name)) {
+          auto *Record = dyn_cast<CXXRecordDecl>(Found);
+          if (Record && Record->isInjectedClassName()) {
+            Injected = Record;
+            break;
+          }
+        }
+        // Create an injected type for the whole redecl chain.
+        SmallVector<Decl *, 2> Redecls =
+            getCanonicalForwardRedeclChain(D2CXX);
+        for (auto *R : Redecls) {
+          auto *RI = cast<CXXRecordDecl>(R);
+          RI->setTypeForDecl(nullptr);
+          // Below we create a new injected type and assign that to the
+          // canonical decl, subsequent declarations in the chain will reuse
+          // that type.
+          Importer.getToContext().getInjectedClassNameType(
+              RI, ToDescribed->getInjectedClassNameSpecialization());
+        }
+        // Set the new type for the previous injected decl too.
+        if (Injected) {
+          Injected->setTypeForDecl(nullptr);
+          Importer.getToContext().getTypeDeclType(Injected, D2CXX);
+        }
+      }
+    } else if (MemberSpecializationInfo *MemberInfo =
+                 DCXX->getMemberSpecializationInfo()) {
+      TemplateSpecializationKind SK =
+          MemberInfo->getTemplateSpecializationKind();
+      CXXRecordDecl *FromInst = DCXX->getInstantiatedFromMemberClass();
+      CXXRecordDecl *ToInst =
+          cast_or_null<CXXRecordDecl>(Importer.Import(FromInst));
+      if (FromInst && !ToInst)
+        return nullptr;
+      D2CXX->setInstantiationOfMemberClass(ToInst, SK);
+      D2CXX->getMemberSpecializationInfo()->setPointOfInstantiation(
+            Importer.Import(MemberInfo->getPointOfInstantiation()));
+    }
+
+  } else {
+    if (GetImportedOrCreateDecl(D2, D, Importer.getToContext(),
+                                D->getTagKind(), DC, StartLoc, Loc,
+                                Name.getAsIdentifierInfo(), PrevDecl))
+      return D2;
+    D2->setLexicalDeclContext(LexicalDC);
+    LexicalDC->addDeclInternal(D2);
   }
 
-  Importer.MapImported(D, D2);
+  D2->setQualifierInfo(Importer.Import(D->getQualifierLoc()));
+  if (D->isAnonymousStructOrUnion())
+    D2->setAnonymousStructOrUnion(true);
 
   if (D->isCompleteDefinition() && ImportDefinition(D, D2, IDK_Default))
     return nullptr;
@@ -4456,14 +4463,13 @@ static ClassTemplateDecl *getDefinition(ClassTemplateDecl *D) {
 Decl *ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
   bool IsFriend = D->getFriendObjectKind() != Decl::FOK_None;
 
-  // If this record has a definition in the translation unit we're coming from,
-  // but this particular declaration is not that definition, import the
+  // If this template has a definition in the translation unit we're coming
+  // from, but this particular declaration is not that definition, import the
   // definition and map to that.
-  CXXRecordDecl *Definition 
-    = cast_or_null<CXXRecordDecl>(D->getTemplatedDecl()->getDefinition());
-  if (Definition && Definition != D->getTemplatedDecl() && !IsFriend) {
+  ClassTemplateDecl *Definition = getDefinition(D);
+  if (Definition && Definition != D && !IsFriend) {
     Decl *ImportedDef
-      = Importer.Import(Definition->getDescribedClassTemplate());
+      = Importer.Import(Definition);
     if (!ImportedDef)
       return nullptr;
 
@@ -4480,38 +4486,28 @@ Decl *ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
   if (ToD)
     return ToD;
 
+  ClassTemplateDecl *FoundByLookup = nullptr;
+
   // We may already have a template of the same name; try to find and match it.
   if (!DC->isFunctionOrMethod()) {
     SmallVector<NamedDecl *, 4> ConflictingDecls;
     SmallVector<NamedDecl *, 2> FoundDecls;
     DC->getRedeclContext()->localUncachedLookup(Name, FoundDecls);
     for (unsigned I = 0, N = FoundDecls.size(); I != N; ++I) {
-      if (!FoundDecls[I]->isInIdentifierNamespace(Decl::IDNS_Ordinary))
+      if (!FoundDecls[I]->isInIdentifierNamespace(Decl::IDNS_Ordinary | Decl::IDNS_TagFriend))
         continue;
 
       Decl *Found = FoundDecls[I];
-      if (auto *FoundTemplate = dyn_cast<ClassTemplateDecl>(Found)) {
-
-        // The class to be imported is a definition.
-        if (D->isThisDeclarationADefinition()) {
-          // Lookup will find the fwd decl only if that is more recent than the
-          // definition. So, try to get the definition if that is available in
-          // the redecl chain.
-          ClassTemplateDecl* TemplateWithDef = getDefinition(FoundTemplate);
-          if (TemplateWithDef)
-            FoundTemplate = TemplateWithDef;
-          else
-            continue;
-        }
+      auto *FoundTemplate = dyn_cast<ClassTemplateDecl>(Found);
+      if (FoundTemplate) {
 
         if (IsStructuralMatch(D, FoundTemplate)) {
-          if (!IsFriend) {
-            Importer.MapImported(D->getTemplatedDecl(),
-                                 FoundTemplate->getTemplatedDecl());
-            return Importer.MapImported(D, FoundTemplate);
+          ClassTemplateDecl* TemplateWithDef = getDefinition(FoundTemplate);
+          if (D->isThisDeclarationADefinition() && TemplateWithDef) {
+            return Importer.MapImported(D, TemplateWithDef);
           }
-
-          continue;
+          FoundByLookup = FoundTemplate;
+          break;
         }
       }
 
@@ -4549,17 +4545,29 @@ Decl *ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
 
   ToTemplated->setDescribedClassTemplate(D2);
 
-  if (ToTemplated->getPreviousDecl()) {
-    assert(
-        ToTemplated->getPreviousDecl()->getDescribedClassTemplate() &&
-        "Missing described template");
-    D2->setPreviousDecl(
-        ToTemplated->getPreviousDecl()->getDescribedClassTemplate());
-  }
   D2->setAccess(D->getAccess());
   D2->setLexicalDeclContext(LexicalDC);
-  if (!IsFriend)
+
+  if (D->getDeclContext()->containsDeclAndLoad(D))
+    DC->addDeclInternal(D2);
+  if (DC != LexicalDC && D->getLexicalDeclContext()->containsDeclAndLoad(D))
     LexicalDC->addDeclInternal(D2);
+
+  if (FoundByLookup) {
+    auto *Recent =
+        const_cast<ClassTemplateDecl *>(FoundByLookup->getMostRecentDecl());
+    // FIXME create a test for this case!
+    if (!ToTemplated->getPreviousDecl()) {
+      auto *PrevTemplated = FoundByLookup->getTemplatedDecl()->getMostRecentDecl();
+      if (ToTemplated != PrevTemplated)
+        ToTemplated->setPreviousDecl(PrevTemplated);
+    }
+    D2->setPreviousDecl(Recent);
+  }
+
+  if (LexicalDC != DC && IsFriend) {
+    DC->makeDeclVisibleInContext(D2);
+  }
 
   if (FromTemplated->isCompleteDefinition() &&
       !ToTemplated->isCompleteDefinition()) {

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2274,10 +2274,18 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
       }
 
       if (auto *FoundRecord = dyn_cast<RecordDecl>(Found)) {
-        if (!SearchName) {
+        // Do not emit false positive diagnostic in case of unnamed
+        // struct/union and in case of anonymous structs.  Would be false
+        // becasue there may be several anonymous/unnamed structs in a class.
+        // E.g. these are both valid:
+        //  struct A { // unnamed structs
+        //    struct { struct A *next; } entry0;
+        //    struct { struct A *next; } entry1;
+        //  };
+        //  struct X { struct { int a; }; struct { int b; }; // anon structs
+        if (!SearchName)
           if (!IsStructuralMatch(D, FoundRecord, false))
             continue;
-        }
 
         if (IsStructuralMatch(D, FoundRecord)) {
           RecordDecl *FoundDef = FoundRecord->getDefinition();

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2357,9 +2357,7 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
     D2->setAccess(D->getAccess());
     D2->setLexicalDeclContext(LexicalDC);
 
-    if (D->getDeclContext()->containsDeclAndLoad(D))
-      DC->addDeclInternal(D2);
-    if (DC != LexicalDC && D->getLexicalDeclContext()->containsDeclAndLoad(D))
+    if (!DCXX->getDescribedClassTemplate() || DCXX->isImplicit())
       LexicalDC->addDeclInternal(D2);
 
     const bool IsFriend = D->isInIdentifierNamespace(Decl::IDNS_TagFriend);

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -4494,7 +4494,8 @@ Decl *ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
     SmallVector<NamedDecl *, 2> FoundDecls;
     DC->getRedeclContext()->localUncachedLookup(Name, FoundDecls);
     for (unsigned I = 0, N = FoundDecls.size(); I != N; ++I) {
-      if (!FoundDecls[I]->isInIdentifierNamespace(Decl::IDNS_Ordinary | Decl::IDNS_TagFriend))
+      if (!FoundDecls[I]->isInIdentifierNamespace(Decl::IDNS_Ordinary |
+                                                  Decl::IDNS_TagFriend))
         continue;
 
       Decl *Found = FoundDecls[I];

--- a/lib/AST/DeclBase.cpp
+++ b/lib/AST/DeclBase.cpp
@@ -1427,7 +1427,9 @@ void DeclContext::removeDecl(Decl *D) {
       if (Map) {
         StoredDeclsMap::iterator Pos = Map->find(ND->getDeclName());
         assert(Pos != Map->end() && "no lookup entry for decl");
-        if (Pos->second.getAsVector() || Pos->second.getAsDecl() == ND)
+        // Remove the decl only if it is contained.
+        if ((Pos->second.getAsVector() && Pos->second.containsInVector(ND)) ||
+            Pos->second.getAsDecl() == ND)
           Pos->second.remove(ND);
       }
     } while (DC->isTransparentContext() && (DC = DC->getParent()));

--- a/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -583,6 +583,8 @@ const internal::VariadicDynCastAllOfMatcher<Decl, CXXConversionDecl>
     cxxConversionDecl;
 const internal::VariadicDynCastAllOfMatcher<Decl, VarDecl> varDecl;
 const internal::VariadicDynCastAllOfMatcher<Decl, FieldDecl> fieldDecl;
+const internal::VariadicDynCastAllOfMatcher<Decl, IndirectFieldDecl>
+    indirectFieldDecl;
 const internal::VariadicDynCastAllOfMatcher<Decl, FunctionDecl> functionDecl;
 const internal::VariadicDynCastAllOfMatcher<Decl, FunctionTemplateDecl>
     functionTemplateDecl;

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4324,7 +4324,7 @@ TEST_P(ImportClassTemplates, ImportDefinitions) {
   EXPECT_EQ(DeclCounter<ClassTemplateDecl>().match(ToTU, Pattern), 1u);
   auto To0 = FirstDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(Imported0 == To0);
-  EXPECT_TRUE(To0->getTemplatedDecl());
+  ASSERT_TRUE(To0->getTemplatedDecl());
   EXPECT_TRUE(To0->isThisDeclarationADefinition());
 }
 

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4209,11 +4209,11 @@ TEST_P(ImportFriendClasses,
       Lang_CXX, "input0.cc");
   auto *Definition = FirstDeclMatcher<ClassTemplateDecl>().match(
       FromTU, classTemplateDecl(hasName("F")));
-  auto *Imported = cast<ClassTemplateDecl>(Import(Definition, Lang_CXX));
-  EXPECT_TRUE(Imported->getPreviousDecl());
-  EXPECT_EQ(ToDecl, Imported->getPreviousDecl());
+  auto *ImportedDef = cast<ClassTemplateDecl>(Import(Definition, Lang_CXX));
+  EXPECT_TRUE(ImportedDef->getPreviousDecl());
+  EXPECT_EQ(ToDecl, ImportedDef->getPreviousDecl());
   EXPECT_EQ(ToDecl->getTemplatedDecl(),
-            Imported->getTemplatedDecl()->getPreviousDecl());
+            ImportedDef->getTemplatedDecl()->getPreviousDecl());
 }
 
 TEST_P(ImportFriendClasses,
@@ -4231,7 +4231,7 @@ TEST_P(ImportFriendClasses,
       Lang_CXX, "input0.cc");
   auto *Fwd = FirstDeclMatcher<ClassTemplateDecl>().match(
       FromTU0, classTemplateDecl(hasName("F")));
-  auto *Imported0 = cast<ClassTemplateDecl>(Import(Fwd, Lang_CXX));
+  auto *ImportedFwd = cast<ClassTemplateDecl>(Import(Fwd, Lang_CXX));
   Decl *FromTU1 = getTuDecl(
       R"(
       template <typename T>
@@ -4240,11 +4240,11 @@ TEST_P(ImportFriendClasses,
       Lang_CXX, "input1.cc");
   auto *Definition = FirstDeclMatcher<ClassTemplateDecl>().match(
       FromTU1, classTemplateDecl(hasName("F")));
-  auto *Imported1 = cast<ClassTemplateDecl>(Import(Definition, Lang_CXX));
-  EXPECT_TRUE(Imported1->getPreviousDecl());
-  EXPECT_EQ(Imported0, Imported1->getPreviousDecl());
-  EXPECT_EQ(Imported0->getTemplatedDecl(),
-            Imported1->getTemplatedDecl()->getPreviousDecl());
+  auto *ImportedDef = cast<ClassTemplateDecl>(Import(Definition, Lang_CXX));
+  EXPECT_TRUE(ImportedDef->getPreviousDecl());
+  EXPECT_EQ(ImportedFwd, ImportedDef->getPreviousDecl());
+  EXPECT_EQ(ImportedFwd->getTemplatedDecl(),
+            ImportedDef->getTemplatedDecl()->getPreviousDecl());
 }
 
 TEST_P(ImportFriendClasses, ImportOfClassDefinitionAndFwdFriendShouldBeLinked) {
@@ -4261,18 +4261,18 @@ TEST_P(ImportFriendClasses, ImportOfClassDefinitionAndFwdFriendShouldBeLinked) {
   auto *Friend = FirstDeclMatcher<FriendDecl>().match(FromTU0, friendDecl());
   QualType FT = Friend->getFriendType()->getType();
   FT = FromTU0->getASTContext().getCanonicalType(FT);
-  auto *Definition = cast<TagType>(FT)->getDecl();
-  auto *Imported0 = Import(Definition, Lang_CXX);
+  auto *Fwd = cast<TagType>(FT)->getDecl();
+  auto *ImportedFwd = Import(Fwd, Lang_CXX);
   Decl *FromTU1 = getTuDecl(
       R"(
       class F {};
       )",
       Lang_CXX, "input1.cc");
-  Definition = FirstDeclMatcher<CXXRecordDecl>().match(
+  auto *Definition = FirstDeclMatcher<CXXRecordDecl>().match(
       FromTU1, cxxRecordDecl(hasName("F")));
-  auto *Imported1 = Import(Definition, Lang_CXX);
-  EXPECT_TRUE(Imported1->getPreviousDecl());
-  EXPECT_EQ(Imported0, Imported1->getPreviousDecl());
+  auto *ImportedDef = Import(Definition, Lang_CXX);
+  EXPECT_TRUE(ImportedDef->getPreviousDecl());
+  EXPECT_EQ(ImportedFwd, ImportedDef->getPreviousDecl());
 }
 
 INSTANTIATE_TEST_CASE_P(ParameterizedTests, DeclContextTest,

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4236,8 +4236,8 @@ TEST_P(ImportClassTemplates,
   EXPECT_EQ(DeclCounter<ClassTemplateDecl>().match(ToTU, Pattern), 1u);
   auto ToD = LastDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(ImportedD == ToD);
+  ASSERT_TRUE(ToD->getTemplatedDecl());
   EXPECT_FALSE(ToD->isThisDeclarationADefinition());
-  EXPECT_TRUE(ToD->getTemplatedDecl());
 }
 
 TEST_P(ImportClassTemplates, ImportPrototypeAfterImportedPrototype) {
@@ -4256,11 +4256,11 @@ TEST_P(ImportClassTemplates, ImportPrototypeAfterImportedPrototype) {
   auto To1 = LastDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(Imported0 == To0);
   EXPECT_TRUE(Imported1 == To1);
+  ASSERT_TRUE(To0->getTemplatedDecl());
+  ASSERT_TRUE(To1->getTemplatedDecl());
   EXPECT_FALSE(To0->isThisDeclarationADefinition());
   EXPECT_FALSE(To1->isThisDeclarationADefinition());
   EXPECT_EQ(To1->getPreviousDecl(), To0);
-  EXPECT_TRUE(To0->getTemplatedDecl());
-  EXPECT_TRUE(To1->getTemplatedDecl());
   EXPECT_EQ(To1->getTemplatedDecl()->getPreviousDecl(),
             To0->getTemplatedDecl());
 }
@@ -4275,8 +4275,8 @@ TEST_P(ImportClassTemplates, DefinitionShouldBeImportedAsADefinition) {
 
   EXPECT_EQ(DeclCounter<ClassTemplateDecl>().match(ToTU, Pattern), 1u);
   auto ToD = LastDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
+  ASSERT_TRUE(ToD->getTemplatedDecl());
   EXPECT_TRUE(ToD->isThisDeclarationADefinition());
-  EXPECT_TRUE(ToD->getTemplatedDecl());
 }
 
 TEST_P(ImportClassTemplates,
@@ -4298,11 +4298,11 @@ TEST_P(ImportClassTemplates,
   auto To1 = LastDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(Imported0 == To0);
   EXPECT_TRUE(Imported1 == To1);
+  ASSERT_TRUE(To0->getTemplatedDecl());
+  ASSERT_TRUE(To1->getTemplatedDecl());
   EXPECT_FALSE(To0->isThisDeclarationADefinition());
   EXPECT_FALSE(To1->isThisDeclarationADefinition());
   EXPECT_EQ(To1->getPreviousDecl(), To0);
-  EXPECT_TRUE(To0->getTemplatedDecl());
-  EXPECT_TRUE(To1->getTemplatedDecl());
   EXPECT_EQ(To1->getTemplatedDecl()->getPreviousDecl(),
             To0->getTemplatedDecl());
 }
@@ -4324,8 +4324,8 @@ TEST_P(ImportClassTemplates, ImportDefinitions) {
   EXPECT_EQ(DeclCounter<ClassTemplateDecl>().match(ToTU, Pattern), 1u);
   auto To0 = FirstDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(Imported0 == To0);
-  EXPECT_TRUE(To0->isThisDeclarationADefinition());
   EXPECT_TRUE(To0->getTemplatedDecl());
+  EXPECT_TRUE(To0->isThisDeclarationADefinition());
 }
 
 TEST_P(ImportClassTemplates, ImportDefinitionThenPrototype) {
@@ -4348,11 +4348,11 @@ TEST_P(ImportClassTemplates, ImportDefinitionThenPrototype) {
   auto ToProto = LastDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(ImportedDef == ToDef);
   EXPECT_TRUE(ImportedProto == ToProto);
+  ASSERT_TRUE(ToDef->getTemplatedDecl());
+  ASSERT_TRUE(ToProto->getTemplatedDecl());
   EXPECT_TRUE(ToDef->isThisDeclarationADefinition());
   EXPECT_FALSE(ToProto->isThisDeclarationADefinition());
   EXPECT_EQ(ToProto->getPreviousDecl(), ToDef);
-  EXPECT_TRUE(ToDef->getTemplatedDecl());
-  EXPECT_TRUE(ToProto->getTemplatedDecl());
   EXPECT_EQ(ToProto->getTemplatedDecl()->getPreviousDecl(),
             ToDef->getTemplatedDecl());
 }
@@ -4377,11 +4377,11 @@ TEST_P(ImportClassTemplates, ImportPrototypeThenDefinition) {
   auto ToDef = LastDeclMatcher<ClassTemplateDecl>().match(ToTU, Pattern);
   EXPECT_TRUE(ImportedDef == ToDef);
   EXPECT_TRUE(ImportedProto == ToProto);
+  ASSERT_TRUE(ToProto->getTemplatedDecl());
+  ASSERT_TRUE(ToDef->getTemplatedDecl());
   EXPECT_TRUE(ToDef->isThisDeclarationADefinition());
   EXPECT_FALSE(ToProto->isThisDeclarationADefinition());
   EXPECT_EQ(ToDef->getPreviousDecl(), ToProto);
-  EXPECT_TRUE(ToProto->getTemplatedDecl());
-  EXPECT_TRUE(ToDef->getTemplatedDecl());
   EXPECT_EQ(ToDef->getTemplatedDecl()->getPreviousDecl(),
             ToProto->getTemplatedDecl());
 }

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -606,6 +606,77 @@ TEST_F(StructuralEquivalenceRecordTest, UnnamedRecordsShouldBeInequivalent) {
   EXPECT_FALSE(testStructuralMatch(R0, R1));
 }
 
+TEST_F(StructuralEquivalenceRecordTest, AnonymousRecordsShouldBeInequivalent) {
+  auto t = makeTuDecls(
+      R"(
+      struct X {
+        struct {
+          int a;
+        };
+        struct {
+          int b;
+        };
+      };
+      )",
+      "", Lang_C);
+  auto *TU = get<0>(t);
+  auto *A = FirstDeclMatcher<IndirectFieldDecl>().match(
+      TU, indirectFieldDecl(hasName("a")));
+  auto *FA = cast<FieldDecl>(A->chain().front());
+  RecordDecl *RA = cast<RecordType>(FA->getType().getTypePtr())->getDecl();
+  auto *B = FirstDeclMatcher<IndirectFieldDecl>().match(
+      TU, indirectFieldDecl(hasName("b")));
+  auto *FB = cast<FieldDecl>(B->chain().front());
+  RecordDecl *RB = cast<RecordType>(FB->getType().getTypePtr())->getDecl();
+
+  ASSERT_NE(RA, RB);
+  EXPECT_TRUE(testStructuralMatch(RA, RA));
+  EXPECT_TRUE(testStructuralMatch(RB, RB));
+  EXPECT_FALSE(testStructuralMatch(RA, RB));
+}
+
+TEST_F(StructuralEquivalenceRecordTest,
+       RecordsAreInequivalentIfOrderOfAnonRecordsIsDifferent) {
+  auto t = makeTuDecls(
+      R"(
+      struct X {
+        struct { int a; };
+        struct { int b; };
+      };
+      )",
+      R"(
+      struct X { // The order is reversed.
+        struct { int b; };
+        struct { int a; };
+      };
+      )",
+      Lang_C);
+
+  auto *TU = get<0>(t);
+  auto *A = FirstDeclMatcher<IndirectFieldDecl>().match(
+      TU, indirectFieldDecl(hasName("a")));
+  auto *FA = cast<FieldDecl>(A->chain().front());
+  RecordDecl *RA = cast<RecordType>(FA->getType().getTypePtr())->getDecl();
+
+  auto *TU1 = get<1>(t);
+  auto *A1 = FirstDeclMatcher<IndirectFieldDecl>().match(
+      TU1, indirectFieldDecl(hasName("a")));
+  auto *FA1 = cast<FieldDecl>(A1->chain().front());
+  RecordDecl *RA1 = cast<RecordType>(FA1->getType().getTypePtr())->getDecl();
+
+  RecordDecl *X =
+      FirstDeclMatcher<RecordDecl>().match(TU, recordDecl(hasName("X")));
+  RecordDecl *X1 =
+      FirstDeclMatcher<RecordDecl>().match(TU1, recordDecl(hasName("X")));
+  ASSERT_NE(X, X1);
+  EXPECT_FALSE(testStructuralMatch(X, X1));
+
+  ASSERT_NE(RA, RA1);
+  EXPECT_TRUE(testStructuralMatch(RA, RA));
+  EXPECT_TRUE(testStructuralMatch(RA1, RA1));
+  EXPECT_FALSE(testStructuralMatch(RA1, RA));
+}
+
 TEST_F(StructuralEquivalenceRecordTest,
        UnnamedRecordsShouldBeInequivalentEvenIfTheSecondIsBeingDefined) {
   auto Code =


### PR DESCRIPTION
The crux of the issue was that lookup could not find previous decls of
a friend class. The solution involves making the friend declarations
visible in their decl context (i.e. adding them to the lookup table).
This fix involves two other repairs:
(1) We could not handle the addition of injected class types properly
when a redecl chain was involved, now this is fixed.
(2) DeclContext::removeDecl failed if the lookup table in Vector form
did not contain the to be removed element. This caused troubles in
ASTImporter::ImportDeclContext. This is also fixed.

Fixes #484 