### PR TITLE
Fix lookup error in case of nested fwd decls in C

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -44,6 +44,17 @@ class TagDecl;
 class TranslationUnitDecl;
 class TypeSourceInfo;
 
+  namespace IdBasedLookup {
+
+  using Result = SmallVector<NamedDecl *, 2>;
+  // Performs unqualified lookup based on the identifer name.
+  // This does not do qualified lookup (that is based on the DeclContext).
+  Result lookup(DeclarationName Name);
+
+  void dump(const Result &LR);
+
+  } // namespace IdBasedLookup
+
   // \brief Returns with a list of declarations started from the canonical decl
   // then followed by subsequent decls in the translation unit.
   // This gives a canonical list for each entry in the redecl chain.


### PR DESCRIPTION
This fixes the C lang related lookup problem.
```
      // DeclContext based lookup may not find forward declared structs in C.
      // For instance, consider that this code had been already parsed into the
      // "To" context:
      //   struct A { struct X *Xp; };
      // In this case localUncachedLookup will not find the forward decl of X.
      // Thus, we do an identifier based search through the front end specific
      // void pointers whic are injected into the DeclarationName objects.
```