### PR TITLE
[ASTImporter] Using most recent previous decl at importRecordDecl.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2621,7 +2621,7 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
                   return std::move(Err);
             }
           }
-          PrevDecl = FoundRecord;
+          PrevDecl = FoundRecord->getMostRecentDecl();
           break;
         }
       }


### PR DESCRIPTION
The object found in `ASTImporterLookupTable` is probably not the most recent one. Passing not the most recent as PreviousDecl when create the new record can cause problems. One failure (#519) seems to be fixed by this change, but not totally sure (the error appears "sporadically").