### PR TITLE
Use SmallSetVector in ASTImporter specific lookup

### DIFF
--- a/include/clang/AST/ASTImporterLookupTable.h
+++ b/include/clang/AST/ASTImporterLookupTable.h
@@ -18,7 +18,7 @@
 #include "clang/AST/DeclBase.h" // lookup_result
 #include "clang/AST/DeclarationName.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace clang {
 
@@ -51,7 +51,7 @@ class ASTImporterLookupTable {
   // And we collect these lists for each DeclContext.
   // We could have a flat map with (DeclContext, Name) tuple as key, but a two
   // level map seems easier to handle.
-  using DeclList = llvm::SmallPtrSet<NamedDecl *, 2>;
+  using DeclList = llvm::SmallSetVector<NamedDecl *, 2>;
   using NameMap = llvm::SmallDenseMap<DeclarationName, DeclList, 4>;
   using DCMap = llvm::DenseMap<DeclContext *, NameMap>;
 

--- a/lib/AST/ASTImporterLookupTable.cpp
+++ b/lib/AST/ASTImporterLookupTable.cpp
@@ -64,7 +64,7 @@ void ASTImporterLookupTable::add(DeclContext *DC, NamedDecl *ND) {
 
 void ASTImporterLookupTable::remove(DeclContext *DC, NamedDecl *ND) {
   DeclList &Decls = LookupTable[DC][ND->getDeclName()];
-  bool EraseResult = Decls.erase(ND);
+  bool EraseResult = Decls.remove(ND);
   (void)EraseResult;
   assert(EraseResult == true && "Trying to remove not contained Decl");
 }


### PR DESCRIPTION
The difference between SetVector and other sets is that the order of iteration is guaranteed to match the order of insertion into the SetVector. This property is really important for things like sets of pointers. Because pointer values are non-deterministic (e.g. vary across runs of the program on different machines), iterating over the pointers in the set will not be in a well-defined order.