### PR TITLE
[ASTImporter] Add diagnostic error when returning with UnsupportedNode.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -7035,6 +7035,8 @@ ExpectedStmt ASTNodeImporter::VisitMemberExpr(MemberExpr *E) {
 
   if (E->hasExplicitTemplateArgs()) {
     // FIXME: handle template arguments
+    Importer.FromDiag(E->getBeginLoc(), diag::err_unsupported_ast_node)
+        << E->getStmtClassName();
     return make_error<ImportError>(ImportError::UnsupportedConstruct);
   }
 


### PR DESCRIPTION
There was one case when `ASTImporter` returned UnsupportedConstruct error but there was no diagnostic error generated. This should be fixed but until it the diagnostic is needed to detect the place of the problem.