### PR TITLE
Remove NonEquivalentDecls from ASTImporter

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -84,7 +84,6 @@ class TypeSourceInfo;
   class ASTImporter {
     friend class ASTNodeImporter;
   public:
-    using NonEquivalentDeclSet = llvm::DenseSet<std::pair<Decl *, Decl *>>;
     using ImportedCXXBaseSpecifierMap =
         llvm::DenseMap<const CXXBaseSpecifier *, CXXBaseSpecifier *>;
 
@@ -141,10 +140,6 @@ class TypeSourceInfo;
     ///  the "from" source manager to the corresponding CXXBasesSpecifier
     ///  in the "to" source manager.
     ImportedCXXBaseSpecifierMap ImportedCXXBaseSpecifiers;
-
-    /// Declaration (from, to) pairs that are known not to be equivalent
-    /// (which we have already complained about).
-    NonEquivalentDeclSet NonEquivalentDecls;
 
     using FoundDeclsTy = SmallVector<NamedDecl *, 2>;
     FoundDeclsTy FindDeclsInToCtx(DeclContext *DC, DeclarationName Name);
@@ -396,9 +391,6 @@ class TypeSourceInfo;
 
     /// Report a diagnostic in the "from" context.
     DiagnosticBuilder FromDiag(SourceLocation Loc, unsigned DiagID);
-
-    /// Return the set of declarations that we know are not equivalent.
-    NonEquivalentDeclSet &getNonEquivalentDecls() { return NonEquivalentDecls; }
 
     /// Called for ObjCInterfaceDecl, ObjCProtocolDecl, and TagDecl.
     /// Mark the Decl as complete, filling it in as much as possible.

--- a/include/clang/AST/ASTStructuralEquivalence.h
+++ b/include/clang/AST/ASTStructuralEquivalence.h
@@ -53,7 +53,7 @@ struct StructuralEquivalenceContext {
 
   /// Declaration (from, to) pairs that are known not to be equivalent
   /// (which we have already complained about).
-  llvm::DenseSet<std::pair<Decl *, Decl *>> &NonEquivalentDecls;
+  llvm::DenseSet<std::pair<Decl *, Decl *>> NonEquivalentDecls;
 
   StructuralEquivalenceKind EqKind;
 
@@ -67,14 +67,12 @@ struct StructuralEquivalenceContext {
   /// \c true if the last diagnostic came from ToCtx.
   bool LastDiagFromC2 = false;
 
-  StructuralEquivalenceContext(
-      ASTContext &FromCtx, ASTContext &ToCtx,
-      llvm::DenseSet<std::pair<Decl *, Decl *>> &NonEquivalentDecls,
-      StructuralEquivalenceKind EqKind,
-      bool StrictTypeSpelling = false, bool Complain = true)
-      : FromCtx(FromCtx), ToCtx(ToCtx), NonEquivalentDecls(NonEquivalentDecls),
-        EqKind(EqKind), StrictTypeSpelling(StrictTypeSpelling),
-        Complain(Complain) {}
+  StructuralEquivalenceContext(ASTContext &FromCtx, ASTContext &ToCtx,
+                               StructuralEquivalenceKind EqKind,
+                               bool StrictTypeSpelling = false,
+                               bool Complain = true)
+      : FromCtx(FromCtx), ToCtx(ToCtx), EqKind(EqKind),
+        StrictTypeSpelling(StrictTypeSpelling), Complain(Complain) {}
 
   DiagnosticBuilder Diag1(SourceLocation Loc, unsigned DiagID);
   DiagnosticBuilder Diag2(SourceLocation Loc, unsigned DiagID);

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -1976,8 +1976,7 @@ getStructuralEquivalenceKind(const ASTImporter &Importer) {
 bool ASTNodeImporter::IsStructuralMatch(Decl *From, Decl *To, bool Complain) {
   StructuralEquivalenceContext Ctx(
       Importer.getFromContext(), Importer.getToContext(),
-      Importer.getNonEquivalentDecls(), getStructuralEquivalenceKind(Importer),
-      false, Complain);
+      getStructuralEquivalenceKind(Importer), false, Complain);
   return Ctx.IsEquivalent(From, To);
 }
 
@@ -1994,7 +1993,6 @@ bool ASTNodeImporter::IsStructuralMatch(RecordDecl *FromRecord,
 
   StructuralEquivalenceContext Ctx(Importer.getFromContext(),
                                    ToRecord->getASTContext(),
-                                   Importer.getNonEquivalentDecls(),
                                    getStructuralEquivalenceKind(Importer),
                                    false, Complain);
   return Ctx.IsEquivalent(FromRecord, ToRecord);
@@ -2004,15 +2002,14 @@ bool ASTNodeImporter::IsStructuralMatch(VarDecl *FromVar, VarDecl *ToVar,
                                         bool Complain) {
   StructuralEquivalenceContext Ctx(
       Importer.getFromContext(), Importer.getToContext(),
-      Importer.getNonEquivalentDecls(), getStructuralEquivalenceKind(Importer),
-      false, Complain);
+      getStructuralEquivalenceKind(Importer), false, Complain);
   return Ctx.IsEquivalent(FromVar, ToVar);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(EnumDecl *FromEnum, EnumDecl *ToEnum) {
-  StructuralEquivalenceContext Ctx(
-      Importer.getFromContext(), Importer.getToContext(),
-      Importer.getNonEquivalentDecls(), getStructuralEquivalenceKind(Importer));
+  StructuralEquivalenceContext Ctx(Importer.getFromContext(),
+                                   Importer.getToContext(),
+                                   getStructuralEquivalenceKind(Importer));
   return Ctx.IsEquivalent(FromEnum, ToEnum);
 }
 
@@ -2020,16 +2017,14 @@ bool ASTNodeImporter::IsStructuralMatch(FunctionTemplateDecl *From,
                                         FunctionTemplateDecl *To) {
   StructuralEquivalenceContext Ctx(
       Importer.getFromContext(), Importer.getToContext(),
-      Importer.getNonEquivalentDecls(), getStructuralEquivalenceKind(Importer),
-      false, false);
+      getStructuralEquivalenceKind(Importer), false, false);
   return Ctx.IsEquivalent(From, To);
 }
 
 bool ASTNodeImporter::IsStructuralMatch(FunctionDecl *From, FunctionDecl *To) {
   StructuralEquivalenceContext Ctx(
       Importer.getFromContext(), Importer.getToContext(),
-      Importer.getNonEquivalentDecls(), getStructuralEquivalenceKind(Importer),
-      false, false);
+      getStructuralEquivalenceKind(Importer), false, false);
   return Ctx.IsEquivalent(From, To);
 }
 
@@ -2047,7 +2042,6 @@ bool ASTNodeImporter::IsStructuralMatch(ClassTemplateDecl *From,
                                         ClassTemplateDecl *To) {
   StructuralEquivalenceContext Ctx(Importer.getFromContext(),
                                    Importer.getToContext(),
-                                   Importer.getNonEquivalentDecls(),
                                    getStructuralEquivalenceKind(Importer));
   return Ctx.IsEquivalent(From, To);
 }
@@ -2056,7 +2050,6 @@ bool ASTNodeImporter::IsStructuralMatch(VarTemplateDecl *From,
                                         VarTemplateDecl *To) {
   StructuralEquivalenceContext Ctx(Importer.getFromContext(),
                                    Importer.getToContext(),
-                                   Importer.getNonEquivalentDecls(),
                                    getStructuralEquivalenceKind(Importer));
   return Ctx.IsEquivalent(From, To);
 }
@@ -8529,7 +8522,7 @@ bool ASTImporter::IsStructurallyEquivalent(QualType From, QualType To,
       llvm::consumeError(ToFromOrErr.takeError());
   }
 
-  StructuralEquivalenceContext Ctx(FromContext, ToContext, NonEquivalentDecls,
+  StructuralEquivalenceContext Ctx(FromContext, ToContext,
                                    getStructuralEquivalenceKind(*this), false,
                                    Complain);
   return Ctx.IsEquivalent(From, To);

--- a/lib/AST/ASTStructuralEquivalence.cpp
+++ b/lib/AST/ASTStructuralEquivalence.cpp
@@ -1534,6 +1534,7 @@ bool StructuralEquivalenceContext::IsEquivalent(Decl *D1, Decl *D2) {
   // as a side effect of one inequivalent element in the DeclsToCheck list.
   assert(DeclsToCheck.empty());
   assert(TentativeEquivalences.empty());
+  assert(NonEquivalentDecls.empty());
 
   if (!::IsStructurallyEquivalent(*this, D1, D2))
     return false;

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -7508,14 +7508,13 @@ bool Sema::RequireCompleteType(SourceLocation Loc, QualType T,
 }
 
 bool Sema::hasStructuralCompatLayout(Decl *D, Decl *Suggested) {
-  llvm::DenseSet<std::pair<Decl *, Decl *>> NonEquivalentDecls;
   if (!Suggested)
     return false;
 
   // FIXME: Add a specific mode for C11 6.2.7/1 in StructuralEquivalenceContext
   // and isolate from other C++ specific checks.
   StructuralEquivalenceContext Ctx(
-      D->getASTContext(), Suggested->getASTContext(), NonEquivalentDecls,
+      D->getASTContext(), Suggested->getASTContext(),
       StructuralEquivalenceKind::Default, false /*StrictTypeSpelling*/,
       true /*Complain*/);
   return Ctx.IsEquivalent(D, Suggested);

--- a/test/ASTMerge/class-template/test.cpp
+++ b/test/ASTMerge/class-template/test.cpp
@@ -24,5 +24,4 @@ static_assert(sizeof(X0<int>().getValue(1)) == sizeof(int));
 // CHECK: class-template1.cpp:36:7: note: field 'member' has type 'int' here
 // CHECK: class-template2.cpp:36:9: note: field 'member' has type 'float' here
 
-// CHECK: 6 warnings generated.
 // CHECK-NOT: static_assert

--- a/test/ASTMerge/enum/test.c
+++ b/test/ASTMerge/enum/test.c
@@ -22,4 +22,3 @@
 // CHECK: enum1.c:30:6: note: no corresponding enumerator here
 // CHECK: enum2.c:34:3: warning: external variable 'x5' declared with incompatible types in different translation units ('enum E5' vs. 'enum E5')
 // CHECK: enum1.c:34:3: note: declared here with type 'enum E5'
-// CHECK: 8 warnings generated

--- a/test/ASTMerge/struct/test.c
+++ b/test/ASTMerge/struct/test.c
@@ -34,11 +34,6 @@
 // CHECK: struct1.c:56:10: warning: type 'struct DeeperError' has incompatible definitions in different translation units
 // CHECK: struct1.c:56:35: note: field 'f' has type 'int' here
 // CHECK: struct2.c:53:37: note: field 'f' has type 'float' here
-// CHECK: struct1.c:54:8: warning: type 'struct DeepError' has incompatible definitions in different translation units
-// CHECK: struct1.c:56:41: note: field 'Deeper' has type 'struct DeeperError *' here
-// CHECK: struct2.c:53:43: note: field 'Deeper' has type 'struct DeeperError *' here
-// CHECK: struct2.c:54:3: warning: external variable 'xDeep' declared with incompatible types in different translation units ('struct DeepError' vs. 'struct DeepError')
-// CHECK: struct1.c:57:3: note: declared here with type 'struct DeepError'
 // CHECK: struct1.c:74:9: warning: type 'S13' has incompatible definitions in different translation units
 // CHECK: struct1.c:75:9: note: field 'i' has type 'Float' (aka 'float') here
 // CHECK: struct2.c:72:7: note: field 'i' has type 'int' here
@@ -47,9 +42,5 @@
 // CHECK: struct1.c:130:7: warning: type 'struct DeepUnnamedError::(anonymous at [[PATH_TO_INPUTS:.+]]struct1.c:130:7)' has incompatible definitions in different translation units
 // CHECK: struct1.c:131:14: note: field 'i' has type 'long' here
 // CHECK: struct2.c:128:15: note: field 'i' has type 'float' here
-// CHECK: struct1.c:129:5: warning: type 'union DeepUnnamedError::(anonymous at [[PATH_TO_INPUTS]]struct1.c:129:5)' has incompatible definitions in different translation units
-// CHECK: struct1.c:132:9: note: field 'S' has type 'struct (anonymous struct at [[PATH_TO_INPUTS]]struct1.c:130:7)' here
-// CHECK: struct2.c:129:9: note: field 'S' has type 'struct (anonymous struct at [[PATH_TO_INPUTS]]struct2.c:127:7)' here
 // CHECK: struct2.c:138:3: warning: external variable 'x16' declared with incompatible types in different translation units ('struct DeepUnnamedError' vs. 'struct DeepUnnamedError')
 // CHECK: struct1.c:141:3: note: declared here with type 'struct DeepUnnamedError'
-// CHECK: 20 warnings generated

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -78,14 +78,12 @@ struct StructuralEquivalenceTest : ::testing::Test {
   }
 
   bool testStructuralMatch(Decl *D0, Decl *D1) {
-    llvm::DenseSet<std::pair<Decl *, Decl *>> NonEquivalentDecls01;
-    llvm::DenseSet<std::pair<Decl *, Decl *>> NonEquivalentDecls10;
-    StructuralEquivalenceContext Ctx01(
-        D0->getASTContext(), D1->getASTContext(),
-        NonEquivalentDecls01, StructuralEquivalenceKind::Default, false, false);
-    StructuralEquivalenceContext Ctx10(
-        D1->getASTContext(), D0->getASTContext(),
-        NonEquivalentDecls10, StructuralEquivalenceKind::Default, false, false);
+    StructuralEquivalenceContext Ctx01(D0->getASTContext(), D1->getASTContext(),
+                                       StructuralEquivalenceKind::Default,
+                                       false, false);
+    StructuralEquivalenceContext Ctx10(D1->getASTContext(), D0->getASTContext(),
+                                       StructuralEquivalenceKind::Default,
+                                       false, false);
     bool Eq01 = Ctx01.IsEquivalent(D0, D1);
     bool Eq10 = Ctx10.IsEquivalent(D1, D0);
     EXPECT_EQ(Eq01, Eq10);


### PR DESCRIPTION
Currently `ASTImporter::NonEquivalentDecls` member keeps its state and shares it between consecutive calls of `StructuralEquivalenceContesxt::IsEquivalent()`.

However, it seems like `NonEquivalentDecls` behaves similarly to other internal states of `StructuralEquivalenceContext` (`TentativeEquivalences`, `DeclsToCheck`).
I.e this state too should be reset before each `IsEquivalent()` call.

The reason:
I have observed, that when we compare two entities and they happen to be unequal *via redecl chain mismatch*, then, from a subsequent compare we may falsely use this cached inequality value. It is extremely hard to justify this statement, this is rather a suspicion. But it seems to be synchronized with other observations related to the inner state of `StructuralEquivalenceContext`. See, https://github.com/Ericsson/clang/pull/383