### PR TITLE
Remove use of makeDeclVisibleInContext

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2684,11 +2684,6 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
     if (!DCXX->getDescribedClassTemplate() || DCXX->isImplicit())
       LexicalDC->addDeclInternal(D2);
 
-    const bool IsFriend = D->isInIdentifierNamespace(Decl::IDNS_TagFriend);
-    if (LexicalDC != DC && IsFriend) {
-      DC->makeDeclVisibleInContext(D2);
-    }
-
     if (ClassTemplateDecl *FromDescribed =
         DCXX->getDescribedClassTemplate()) {
       ClassTemplateDecl *ToDescribed;
@@ -3202,23 +3197,11 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
   if (Error Err = ImportTemplateInformation(D, ToFunction))
     return std::move(Err);
 
-  bool IsFriend = D->isInIdentifierNamespace(Decl::IDNS_OrdinaryFriend);
-
   // TODO Can we generalize this approach to other AST nodes as well?
   if (D->getDeclContext()->containsDeclAndLoad(D))
     DC->addDeclInternal(ToFunction);
   if (DC != LexicalDC && D->getLexicalDeclContext()->containsDeclAndLoad(D))
     LexicalDC->addDeclInternal(ToFunction);
-
-  // Friend declaration's lexical context is the befriending class, but the
-  // semantic context is the enclosing scope of the befriending class.
-  // We want the friend functions to be found in the semantic context by lookup.
-  // FIXME should we handle this generically in VisitFriendDecl?
-  // In Other cases when LexicalDC != DC we don't want it to be added,
-  // e.g out-of-class definitions like void B::f() {} .
-  if (LexicalDC != DC && IsFriend) {
-    DC->makeDeclVisibleInContext(ToFunction);
-  }
 
   if (auto *FromCXXMethod = dyn_cast<CXXMethodDecl>(D))
     ImportOverrides(cast<CXXMethodDecl>(ToFunction), FromCXXMethod);
@@ -4916,7 +4899,6 @@ template <typename T> static auto getDefinition(T *D) -> T * {
 }
 
 ExpectedDecl ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
-  bool IsFriend = D->getFriendObjectKind() != Decl::FOK_None;
 
   // Import the major distinguishing characteristics of this class template.
   DeclContext *DC, *LexicalDC;
@@ -5013,10 +4995,6 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateDecl(ClassTemplateDecl *D) {
     }
 
     D2->setPreviousDecl(Recent);
-  }
-
-  if (LexicalDC != DC && IsFriend) {
-    DC->makeDeclVisibleInContext(D2);
   }
 
   if (FromTemplated->isCompleteDefinition() &&

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2176,7 +2176,7 @@ TEST_P(ImportFriendFunctions, Lookup) {
   auto LookupRes = Class->noload_lookup(ToName);
   EXPECT_EQ(LookupRes.size(), 0u);
   LookupRes = ToTU->noload_lookup(ToName);
-  EXPECT_EQ(LookupRes.size(), 1u);
+  EXPECT_EQ(LookupRes.size(), 0u);
 
   EXPECT_EQ(DeclCounter<FunctionDecl>().match(ToTU, FunctionPattern), 1u);
   auto *To0 = FirstDeclMatcher<FunctionDecl>().match(ToTU, FunctionPattern);
@@ -2184,7 +2184,7 @@ TEST_P(ImportFriendFunctions, Lookup) {
   EXPECT_FALSE(To0->isInIdentifierNamespace(Decl::IDNS_Ordinary));
 }
 
-TEST_P(ImportFriendFunctions, DISABLED_LookupWithProtoAfter) {
+TEST_P(ImportFriendFunctions, LookupWithProtoAfter) {
   auto FunctionPattern = functionDecl(hasName("f"));
   auto ClassPattern = cxxRecordDecl(hasName("X"));
 


### PR DESCRIPTION
In the past we had to use `DeclContext::makeDeclVisibleInContext` to make friend declarations available for subsequent lookup calls and this way we could chain (redecl) the structurally equivalent decls.
Since we use the importer specific lookup this is no longer necessary, because with that we can find every previous nodes.