### PR TITLE
Set the described template if not set

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2710,6 +2710,9 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
             getCanonicalForwardRedeclChain(D2CXX);
         for (auto *R : Redecls) {
           auto *RI = cast<CXXRecordDecl>(R);
+          // Existing Decl in the chain might not have the described
+          // template set, so we set it now.
+          RI->setDescribedClassTemplate(ToDescribed);
           RI->setTypeForDecl(nullptr);
           // Below we create a new injected type and assign that to the
           // canonical decl, subsequent declarations in the chain will reuse


### PR DESCRIPTION
During the addition of an injected class type to a record it may happen
that a CXXRecordDecl in the redecl chain does not have a set described
template and this caused an assert in LLDB in macOS (but not in Linux).