### PR TITLE
Fix in self assignment checker

### DIFF
--- a/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -450,7 +450,7 @@ static bool shouldSkipFunction(const Decl *D,
   // where it may not. (cplusplus.SelfAssignmentChecker)
   if (const auto *MD = dyn_cast<CXXMethodDecl>(D)) {
     if (MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator())
-      return false;
+      return !MD->isUserProvided();
   }
 
   // Otherwise, if we visited the function before, do not reanalyze it.


### PR DESCRIPTION
For self assignment checker it was necessary to force checking
checking of assignment operators even if those are not called.
The reason if this is to check whether "this" is equal to the
address of the assignee object.

The buffer overflow checker checks if the intervals of the
arguments of a memcpy() call are disjoint. If a class has an
array member then the compiler generated assignment operator
copies it with memcpy() function without checking self assignment
at the beginning. Since the analyzer forces the check of assignment
operators, the buffer overflow checker reported a false positive
on classes with compiler generated assignment operator and array
member.

This commit prevents the forced check of compiler generated assignment
operators.