### PR TITLE
Handle type-aliased friend declarations in ASTImporterLookupTable

### DIFF
--- a/lib/AST/ASTImporterLookupTable.cpp
+++ b/lib/AST/ASTImporterLookupTable.cpp
@@ -30,8 +30,8 @@ struct Builder : RecursiveASTVisitor<Builder> {
   // In most cases the FriendDecl inside the referencing class contains the
   // declaration of the "befriended class" as a child node, so it is discovered
   // during the recursive visitation. Dependent types behave this way. In some
-  // other cases the "befriended class" must be visited explicitly, and this is
-  // simulated by adding its declaration to the lookup table.
+  // other cases the non-child "befriended class" must be fetched explicitly
+  // from the FriendDecl, and only then can we add it to the lookup table.
   bool VisitFriendDecl(FriendDecl *D) {
     if (D->getFriendType()) {
       QualType Ty = D->getFriendType()->getType();

--- a/lib/AST/ASTImporterLookupTable.cpp
+++ b/lib/AST/ASTImporterLookupTable.cpp
@@ -43,14 +43,12 @@ struct Builder : RecursiveASTVisitor<Builder> {
         // dependent type produces the correct AST structure.
         if (const auto *RTy = dyn_cast<RecordType>(Ty))
           LT.add(RTy->getAsCXXRecordDecl());
-        else if (const auto *SpecTy =
-                     dyn_cast<TemplateSpecializationType>(Ty))
+        else if (const auto *SpecTy = dyn_cast<TemplateSpecializationType>(Ty))
           LT.add(SpecTy->getAsCXXRecordDecl());
         else if (isa<TypedefType>(Ty)) {
           // If we have a forward declaration of an aliased type, nothing
           // should be done.
-        }
-        else {
+        } else {
           llvm_unreachable("Unhandled type of friend class");
         }
       }

--- a/lib/AST/ASTImporterLookupTable.cpp
+++ b/lib/AST/ASTImporterLookupTable.cpp
@@ -27,14 +27,11 @@ struct Builder : RecursiveASTVisitor<Builder> {
     LT.add(D);
     return true;
   }
-  // Friend declarations introduce new types, which should be visible during
-  // lookup of a specific named declaration even if it would be illegal to
-  // reference them at the root level of the TU.
-  // This visitor is necessary because in case of some friend declarations the
-  // AST does not contain the referenced friend class or function as a child of
-  // the referencing declaration, thus causing the recursive discovery fail.
-  // This visitor helps this discovery process by making the lookup table aware
-  // of these "hidden" declarations.
+  // In most cases the FriendDecl inside the referencing class contains the
+  // declaration of the "befriended class" as a child node, so it is discovered
+  // during the recursive visitation. Dependent types behave this way. In some
+  // other cases the "befriended class" must be visited explicitly, and this is
+  // simulated by adding its declaration to the lookup table.
   bool VisitFriendDecl(FriendDecl *D) {
     if (D->getFriendType()) {
       QualType Ty = D->getFriendType()->getType();
@@ -42,18 +39,16 @@ struct Builder : RecursiveASTVisitor<Builder> {
         Ty = cast<ElaboratedType>(Ty)->getNamedType();
       if (!Ty->isDependentType()) {
         // We are concerning ourselves with the case where the type of the
-        // declared type is dependent, as friend declaration with a dependent
-        // type product the correct AST structure.
+        // declared type is not dependent, as friend declaration with a
+        // dependent type produces the correct AST structure.
         if (const auto *RTy = dyn_cast<RecordType>(Ty))
           LT.add(RTy->getAsCXXRecordDecl());
         else if (const auto *SpecTy =
                      dyn_cast<TemplateSpecializationType>(Ty))
           LT.add(SpecTy->getAsCXXRecordDecl());
-        else if (const auto *AliasTy =
-                     dyn_cast<TypedefType>(Ty)) {
+        else if (isa<TypedefType>(Ty)) {
           // If we have a forward declaration of an aliased type, nothing
-          // should be done, however we don't want to mark this case as
-          // unreachable, so this is an empty branch.
+          // should be done.
         }
         else {
           llvm_unreachable("Unhandled type of friend class");

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4037,7 +4037,6 @@ TEST_P(ASTImporterLookupTableTest,
   ASTImporterLookupTable LT(*ToTU);
 
   auto *FriendD = FirstDeclMatcher<FriendDecl>().match(ToTU, friendDecl());
-  auto *Y = FirstDeclMatcher<CXXRecordDecl>().match(ToTU, cxxRecordDecl(hasName("Y")));
   auto *F = FirstDeclMatcher<CXXRecordDecl>().match(ToTU, cxxRecordDecl(hasName("F")));
 
   const RecordDecl *RD = getRecordDeclOfFriend(FriendD);

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4025,7 +4025,7 @@ TEST_P(ASTImporterLookupTableTest,
 }
 
 TEST_P(ASTImporterLookupTableTest,
-       LookupFindsFriendClassDeclWithTypeAlias) {
+       LookupFindsFriendClassDeclWithTypeAliasDoesNotAssert) {
   TranslationUnitDecl *ToTU = getToTuDecl(
       R"(
       class F;
@@ -4034,14 +4034,8 @@ TEST_P(ASTImporterLookupTableTest,
       )",
       Lang_CXX11);
 
+  // ASTImporterLookupTable constructor handles using declarations correctly.
   ASTImporterLookupTable LT(*ToTU);
-
-  auto *FriendD = FirstDeclMatcher<FriendDecl>().match(ToTU, friendDecl());
-  auto *F = FirstDeclMatcher<CXXRecordDecl>().match(ToTU, cxxRecordDecl(hasName("F")));
-
-  const RecordDecl *RD = getRecordDeclOfFriend(FriendD);
-
-  EXPECT_EQ(F, RD);
 }
 
 TEST_P(ASTImporterLookupTableTest, LookupFindsFwdFriendClassTemplateDecl) {

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -3959,16 +3959,16 @@ TEST_P(ASTImporterLookupTableTest, LookupDeclNamesFromDifferentTUs) {
 static QualType getUnderlyingType(const TypedefType *TDT) {
   QualType T = TDT->getDecl()->getUnderlyingType();
 
-  if (const auto * inner = dyn_cast<TypedefType>(T.getTypePtr()))
-    return getUnderlyingType(inner);
+  if (const auto *Inner = dyn_cast<TypedefType>(T.getTypePtr()))
+    return getUnderlyingType(Inner);
 
   return T;
 }
 
 static const RecordDecl * getRecordDeclOfFriend(FriendDecl *FD) {
   QualType Ty = FD->getFriendType()->getType();
-  if (auto * inner = dyn_cast<TypedefType>(Ty.getTypePtr())) {
-    Ty = getUnderlyingType(inner);
+  if (auto *Inner = dyn_cast<TypedefType>(Ty.getTypePtr())) {
+    Ty = getUnderlyingType(Inner);
   }
   if (isa<ElaboratedType>(Ty))
     Ty = cast<ElaboratedType>(Ty)->getNamedType();
@@ -4042,16 +4042,7 @@ TEST_P(ASTImporterLookupTableTest,
 
   const RecordDecl *RD = getRecordDeclOfFriend(FriendD);
 
-  DeclarationName FwdName = F->getDeclName();
-  auto Res = LT.lookup(ToTU, FwdName);
-  EXPECT_EQ(Res.size(), 1u);
-  EXPECT_EQ(*Res.begin(), RD);
-
-  Res = LT.lookup(Y, FwdName);
-  EXPECT_EQ(Res.size(), 0u);
-
-  DeclarationName AliasName = RD->getDeclName();
-  EXPECT_EQ(AliasName, FwdName);
+  EXPECT_EQ(F, RD);
 }
 
 TEST_P(ASTImporterLookupTableTest, LookupFindsFwdFriendClassTemplateDecl) {


### PR DESCRIPTION
There were numerous asserts thanks to type aliased friend declarations, which were not handled in the ASTImporterLookupTable visitor. This patch adds a test case which crashed before, but this implementation fixes the crash. The semantic reasoning for the implementation is summarized in the comments near the change.

fixes #581