### PR TITLE
Propagate error from ImportDeclContext

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -1613,10 +1613,20 @@ Error ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) 
   llvm::SmallVector<Decl *, 8> ImportedDecls;
   for (auto *From : FromDC->decls()) {
     ExpectedDecl ImportedOrErr = import(From);
-    if (!ImportedOrErr)
-      // Ignore the error, continue with next Decl.
-      // FIXME: Handle this case somehow better.
+    if (!ImportedOrErr) {
+      // We use strict error handling in case of records and enums, but not
+      // with e.g. namespaces.
+      //
+      // FIXME Clients of the ASTImporter should be able to choose an
+      // appropriate error handling strategy for their needs.  For instance,
+      // they may not want to mark an entire namespace as erroneous merely
+      // because there is an ODR error with two typedefs.  As another example,
+      // the client may allow EnumConstantDecls with same names but with
+      // different values in two distinct translation units.
+      if (isa<TagDecl>(FromDC))
+        return ImportedOrErr.takeError();
       consumeError(ImportedOrErr.takeError());
+    }
     else
       ImportedDecls.push_back(*ImportedOrErr);
   }


### PR DESCRIPTION
During analysis of one E/// project we failed to import one `CXXDestructorDecl`. But since we did not propagate the error in `importDeclContext` we had a `CXXRecordDecl` without a destructor. Then the analyzer engine had a `CallEvent` where the nonexistent dtor was requested (crash).

Solution is to propagate the errors we have during importing a DeclContext. (Note, this is not trivial which errors to propagate, see the comments in the code.)

By propagating errors it could happen that we tried to remove a decl twice from the `Lookuptable` (crash), hence the second part of the change.