### PR TITLE
Improved FileID import.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8154,15 +8154,22 @@ Expected<FileID> ASTImporter::Import(FileID FromID) {
       // than mmap the files several times.
       const FileEntry *Entry =
           ToFileManager.getFile(Cache->OrigEntry->getName());
-      if (!Entry)
+      // FIXME: The filename may be a virtual name that does probably not
+      // point to a valid file and we get no Entry here. In this case try with
+      // the memory buffer below.
+      if (Entry)
+        ToID = ToSM.createFileID(Entry, *ToIncludeLoc,
+                                 FromSLoc.getFile().getFileCharacteristic());
+    }
+    if (ToID.isInvalid()) {
+      // FIXME: We want to re-use the existing MemoryBuffer!
+      bool Invalid = true;
+      const llvm::MemoryBuffer *FromBuf =
+          Cache->getBuffer(FromContext.getDiagnostics(), FromSM, SourceLocation{}, &Invalid);
+      if (!FromBuf || Invalid)
         // FIXME: Use a new error kind?
         return llvm::make_error<ImportError>(ImportError::Unknown);
-      ToID = ToSM.createFileID(Entry, *ToIncludeLoc,
-                               FromSLoc.getFile().getFileCharacteristic());
-    } else {
-      // FIXME: We want to re-use the existing MemoryBuffer!
-      const llvm::MemoryBuffer *FromBuf =
-          Cache->getBuffer(FromContext.getDiagnostics(), FromSM);
+
       std::unique_ptr<llvm::MemoryBuffer> ToBuf =
           llvm::MemoryBuffer::getMemBufferCopy(FromBuf->getBuffer(),
                                                FromBuf->getBufferIdentifier());
@@ -8170,6 +8177,8 @@ Expected<FileID> ASTImporter::Import(FileID FromID) {
                                FromSLoc.getFile().getFileCharacteristic());
     }
   }
+
+  assert(ToID.isValid() && "Unexpected invalid fileID was created.");
 
   ImportedFileIDs[FromID] = ToID;
   return ToID;

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8164,8 +8164,8 @@ Expected<FileID> ASTImporter::Import(FileID FromID) {
     if (ToID.isInvalid()) {
       // FIXME: We want to re-use the existing MemoryBuffer!
       bool Invalid = true;
-      const llvm::MemoryBuffer *FromBuf =
-          Cache->getBuffer(FromContext.getDiagnostics(), FromSM, SourceLocation{}, &Invalid);
+      const llvm::MemoryBuffer *FromBuf = Cache->getBuffer(
+          FromContext.getDiagnostics(), FromSM, SourceLocation{}, &Invalid);
       if (!FromBuf || Invalid)
         // FIXME: Use a new error kind?
         return llvm::make_error<ImportError>(ImportError::Unknown);


### PR DESCRIPTION
At import of `FileID` sometimes an existing directory entry and filename is encountered, but the filename points to a non-existing file. In this case try with creating the file from memory buffer instead of return an error. (I do not know what exactly happens but this fixes some cases when the FileID could not be     imported on macOS.)