### PR TITLE
Add/remove from the Lookuptable consistently

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -411,6 +411,8 @@ class TypeSourceInfo;
     virtual Decl *Imported(Decl *From, Decl *To) { return To; }
 
     /// Store and assign the imported declaration to its counterpart.
+    /// It may happen that several decls from the 'from' context are mapped to
+    /// the same decl in the 'to' context.
     Decl *MapImported(Decl *From, Decl *To);
 
     /// Deprecated. FIXME use [[deprecated]] once Clang enables C++14.


### PR DESCRIPTION
Add/remove from the Lookuptable in consistency with ImportedFromDecls.
When we map a decl in the 'to' context to something in the 'from'
context then and only then we add it to the lookup table.  When we
remove a mapping then and only then we remove it from the lookup table.