### PR TITLE
Improved import of TypeSourceInfo (TypeLoc).

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -7649,11 +7649,11 @@ Expected<QualType> ASTImporter::Import(QualType FromT) {
 
 namespace clang {
 
-#define IMPORT(NAME) \
-if (auto ImpOrErr = Importer.Import(From.get##NAME())) \
-  To.set##NAME(*ImpOrErr); \
-else \
-  return ImpOrErr.takeError();
+#define IMPORT(NAME)                                                           \
+  if (auto ImpOrErr = Importer.Import(From.get##NAME()))                       \
+    To.set##NAME(*ImpOrErr);                                                   \
+  else                                                                         \
+    return ImpOrErr.takeError();
 
 // Import TypeLoc information.
 // TypeLocReader in ASTReader.cpp gives hints about what to import.

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -43,6 +43,7 @@
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
+#include "clang/AST/TypeLocVisitor.h"
 #include "clang/AST/TypeVisitor.h"
 #include "clang/AST/UnresolvedSet.h"
 #include "clang/Basic/ExceptionSpecificationType.h"
@@ -620,6 +621,8 @@ namespace clang {
 
     Expected<FunctionDecl *> FindFunctionTemplateSpecialization(
         FunctionDecl *FromFD);
+
+    friend class TypeLocImporter;
   };
 
 template <typename InContainerTy>
@@ -7644,20 +7647,514 @@ Expected<QualType> ASTImporter::Import(QualType FromT) {
   return ToContext.getQualifiedType(*ToTOrErr, FromT.getLocalQualifiers());
 }
 
+namespace clang {
+
+// Import TypeLoc information.
+// TypeLocReader in ASTReader.cpp gives hints about what to import.
+// (At some ObjC types not every existing location is copied.)
+class TypeLocImporter : public TypeLocVisitor<TypeLocImporter, Error> {
+  ASTImporter &Importer;
+  TypeLoc ToL;
+
+public:
+  TypeLocImporter(ASTImporter &Importer, TypeLoc ToL)
+      : Importer(Importer), ToL(ToL) {}
+
+  Error VisitTypeSpecTypeLoc(TypeSpecTypeLoc From) {
+    auto To = ToL.castAs<TypeSpecTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getNameLoc()))
+      To.setNameLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitTypedefTypeLoc(TypedefTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitInjectedClassNameTypeLoc(InjectedClassNameTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitUnresolvedUsingTypeLoc(UnresolvedUsingTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitRecordTypeLoc(RecordTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitEnumTypeLoc(EnumTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitTemplateTypeParmTypeLoc(TemplateTypeParmTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitSubstTemplateTypeParmTypeLoc(SubstTemplateTypeParmTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error
+  VisitSubstTemplateTypeParmPackTypeLoc(SubstTemplateTypeParmPackTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitVectorTypeLoc(VectorTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitDependentVectorTypeLoc(DependentVectorTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitExtVectorTypeLoc(ExtVectorTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error
+  VisitDependentSizedExtVectorTypeLoc(DependentSizedExtVectorTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitComplexTypeLoc(ComplexTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitDecltypeTypeLoc(DecltypeTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitDeducedTypeLoc(DeducedTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitAutoTypeLoc(AutoTypeLoc From) {
+    return VisitTypeSpecTypeLoc(From);
+  }
+
+  Error VisitBuiltinTypeLoc(BuiltinTypeLoc From) {
+    auto To = ToL.castAs<BuiltinTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getBuiltinLoc()))
+      To.setBuiltinLoc(*L);
+    else
+      return L.takeError();
+    // FIXME: Import other attributes?
+    return Error::success();
+  }
+
+  Error VisitParenTypeLoc(ParenTypeLoc From) {
+    auto To = ToL.castAs<ParenTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getLParenLoc()))
+      To.setLParenLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRParenLoc()))
+      To.setRParenLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitBlockPointerTypeLoc(BlockPointerTypeLoc From) {
+    auto To = ToL.castAs<BlockPointerTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getCaretLoc()))
+      To.setCaretLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitMemberPointerTypeLoc(MemberPointerTypeLoc From) {
+    auto To = ToL.castAs<MemberPointerTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getStarLoc()))
+      To.setStarLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitLValueReferenceTypeLoc(LValueReferenceTypeLoc From) {
+    auto To = ToL.castAs<LValueReferenceTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getAmpLoc()))
+      To.setAmpLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitRValueReferenceTypeLoc(RValueReferenceTypeLoc From) {
+    auto To = ToL.castAs<RValueReferenceTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getAmpAmpLoc()))
+      To.setAmpAmpLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitFunctionTypeLoc(FunctionTypeLoc From) {
+    auto To = ToL.castAs<FunctionTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getLocalRangeBegin()))
+      To.setLocalRangeBegin(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getLocalRangeEnd()))
+      To.setLocalRangeEnd(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getLParenLoc()))
+      To.setLParenLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRParenLoc()))
+      To.setRParenLoc(*L);
+    else
+      return L.takeError();
+    if (Expected<SourceRange> R = Importer.Import(From.getExceptionSpecRange()))
+      To.setExceptionSpecRange(*R);
+    else
+      return R.takeError();
+    for (unsigned I = 0; I < From.getNumParams(); ++I) {
+      // FIXME: Import params?
+      // (avoided because import of a Decl may cause complication)
+      To.setParam(I, nullptr);
+    }
+    return Error::success();
+  }
+
+  Error VisitArrayTypeLoc(ArrayTypeLoc From) {
+    auto To = ToL.castAs<ArrayTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getLBracketLoc()))
+      To.setLBracketLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRBracketLoc()))
+      To.setRBracketLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedExpr E = Importer.Import(From.getSizeExpr()))
+      To.setSizeExpr(*E);
+    else
+      return E.takeError();
+    return Error::success();
+  }
+
+  Error VisitTemplateSpecializationTypeLoc(TemplateSpecializationTypeLoc From) {
+    auto To = ToL.castAs<TemplateSpecializationTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getTemplateKeywordLoc()))
+      To.setTemplateKeywordLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getLAngleLoc()))
+      To.setLAngleLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRAngleLoc()))
+      To.setRAngleLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getTemplateNameLoc()))
+      To.setTemplateNameLoc(*L);
+    else
+      return L.takeError();
+    ASTNodeImporter NodeImporter(Importer);
+    for (unsigned I = 0; I < From.getNumArgs(); ++I) {
+      if (Expected<TemplateArgumentLoc> TAL =
+              NodeImporter.import(From.getArgLoc(I)))
+        To.setArgLocInfo(I, TAL->getLocInfo());
+      else
+        return TAL.takeError();
+    }
+
+    return Error::success();
+  }
+
+  Error VisitDependentAddressSpaceTypeLoc(DependentAddressSpaceTypeLoc From) {
+    auto To = ToL.castAs<DependentAddressSpaceTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getAttrNameLoc()))
+      To.setAttrNameLoc(*L);
+    else
+      return L.takeError();
+    if (Expected<SourceRange> R =
+            Importer.Import(From.getAttrOperandParensRange()))
+      To.setAttrOperandParensRange(*R);
+    else
+      return R.takeError();
+    // FIXME: Import other things?
+    return Error::success();
+  }
+
+  Error VisitTypeOfTypeLoc(TypeOfTypeLoc From) {
+    auto To = ToL.castAs<TypeOfTypeLoc>();
+    if (Expected<TypeSourceInfo *> TSI =
+            Importer.Import(From.getUnderlyingTInfo()))
+      To.setUnderlyingTInfo(*TSI);
+    else
+      return TSI.takeError();
+    return Error::success();
+  }
+
+  Error VisitUnaryTransformTypeLoc(UnaryTransformTypeLoc From) {
+    auto To = ToL.castAs<UnaryTransformTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getKWLoc()))
+      To.setKWLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getLParenLoc()))
+      To.setLParenLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRParenLoc()))
+      To.setRParenLoc(*L);
+    else
+      return L.takeError();
+    if (Expected<TypeSourceInfo *> TSI =
+            Importer.Import(From.getUnderlyingTInfo()))
+      To.setUnderlyingTInfo(*TSI);
+    else
+      return TSI.takeError();
+    return Error::success();
+  }
+
+  Error VisitDeducedTemplateSpecializationTypeLoc(
+      DeducedTemplateSpecializationTypeLoc From) {
+    auto To = ToL.castAs<DeducedTemplateSpecializationTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getTemplateNameLoc()))
+      To.setTemplateNameLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitElaboratedTypeLoc(ElaboratedTypeLoc From) {
+    auto To = ToL.castAs<ElaboratedTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getElaboratedKeywordLoc()))
+      To.setElaboratedKeywordLoc(*L);
+    else
+      return L.takeError();
+    if (Expected<NestedNameSpecifierLoc> L =
+            Importer.Import(From.getQualifierLoc()))
+      To.setQualifierLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitDependentNameTypeLoc(DependentNameTypeLoc From) {
+    auto To = ToL.castAs<DependentNameTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getElaboratedKeywordLoc()))
+      To.setElaboratedKeywordLoc(*L);
+    else
+      return L.takeError();
+    if (Expected<NestedNameSpecifierLoc> L =
+            Importer.Import(From.getQualifierLoc()))
+      To.setQualifierLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getNameLoc()))
+      To.setNameLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitDependentTemplateSpecializationTypeLoc(
+      DependentTemplateSpecializationTypeLoc From) {
+    auto To = ToL.castAs<DependentTemplateSpecializationTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getElaboratedKeywordLoc()))
+      To.setElaboratedKeywordLoc(*L);
+    else
+      return L.takeError();
+    if (Expected<NestedNameSpecifierLoc> L =
+            Importer.Import(From.getQualifierLoc()))
+      To.setQualifierLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getTemplateKeywordLoc()))
+      To.setTemplateKeywordLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getTemplateNameLoc()))
+      To.setTemplateNameLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getLAngleLoc()))
+      To.setLAngleLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRAngleLoc()))
+      To.setRAngleLoc(*L);
+    else
+      return L.takeError();
+    ASTNodeImporter NodeImporter(Importer);
+    for (unsigned I = 0; I < From.getNumArgs(); ++I) {
+      if (Expected<TemplateArgumentLoc> TAL =
+              NodeImporter.import(From.getArgLoc(I)))
+        To.setArgLocInfo(I, TAL->getLocInfo());
+      else
+        return TAL.takeError();
+    }
+    return Error::success();
+  }
+
+  Error VisitPackExpansionTypeLoc(PackExpansionTypeLoc From) {
+    auto To = ToL.castAs<PackExpansionTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getEllipsisLoc()))
+      To.setEllipsisLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitAtomicTypeLoc(AtomicTypeLoc From) {
+    auto To = ToL.castAs<AtomicTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getKWLoc()))
+      To.setKWLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getLParenLoc()))
+      To.setLParenLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getRParenLoc()))
+      To.setRParenLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitPipeTypeLoc(PipeTypeLoc From) {
+    auto To = ToL.castAs<PipeTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getKWLoc()))
+      To.setKWLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitObjCTypeParamTypeLoc(ObjCTypeParamTypeLoc From) {
+    auto To = ToL.castAs<ObjCTypeParamTypeLoc>();
+    if (From.getNumProtocols()) {
+      if (ExpectedSLoc L = Importer.Import(From.getProtocolLAngleLoc()))
+        To.setProtocolLAngleLoc(*L);
+      else
+        return L.takeError();
+      if (ExpectedSLoc L = Importer.Import(From.getProtocolRAngleLoc()))
+        To.setProtocolRAngleLoc(*L);
+      else
+        return L.takeError();
+      for (unsigned I = 0; I < From.getNumProtocols(); ++I) {
+        if (ExpectedSLoc L = Importer.Import(From.getProtocolLoc(I)))
+          To.setProtocolLoc(I, *L);
+        else
+          return L.takeError();
+      }
+    }
+    return Error::success();
+  }
+
+  Error VisitObjCObjectTypeLoc(ObjCObjectTypeLoc From) {
+    auto To = ToL.castAs<ObjCObjectTypeLoc>();
+
+    if (ExpectedSLoc L = Importer.Import(From.getTypeArgsLAngleLoc()))
+      To.setTypeArgsLAngleLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getTypeArgsRAngleLoc()))
+      To.setTypeArgsRAngleLoc(*L);
+    else
+      return L.takeError();
+
+    for (unsigned I = 0; I < From.getNumTypeArgs(); ++I) {
+      if (Expected<TypeSourceInfo *> TSI =
+              Importer.Import(From.getTypeArgTInfo(I)))
+        To.setTypeArgTInfo(I, *TSI);
+      else
+        return TSI.takeError();
+    }
+
+    if (ExpectedSLoc L = Importer.Import(From.getProtocolLAngleLoc()))
+      To.setProtocolLAngleLoc(*L);
+    else
+      return L.takeError();
+    if (ExpectedSLoc L = Importer.Import(From.getProtocolRAngleLoc()))
+      To.setProtocolRAngleLoc(*L);
+    else
+      return L.takeError();
+
+    for (unsigned I = 0; I < From.getNumProtocols(); ++I) {
+      if (ExpectedSLoc L = Importer.Import(From.getProtocolLoc(I)))
+        To.setProtocolLoc(I, *L);
+      else
+        return L.takeError();
+    }
+
+    To.setHasBaseTypeAsWritten(From.hasBaseTypeAsWritten());
+
+    return Error::success();
+  }
+
+  Error VisitObjCInterfaceTypeLoc(ObjCInterfaceTypeLoc From) {
+    auto To = ToL.castAs<ObjCInterfaceTypeLoc>();
+
+    if (ExpectedSLoc L = Importer.Import(From.getNameLoc()))
+      To.setNameLoc(*L);
+    else
+      return L.takeError();
+
+    return Error::success();
+  }
+
+  Error VisitObjCObjectPointerTypeLoc(ObjCObjectPointerTypeLoc From) {
+    auto To = ToL.castAs<ObjCObjectPointerTypeLoc>();
+    if (ExpectedSLoc L = Importer.Import(From.getStarLoc()))
+      To.setStarLoc(*L);
+    else
+      return L.takeError();
+    return Error::success();
+  }
+
+  Error VisitTypeLoc(TypeLoc TyLoc) { return Error::success(); }
+};
+
+} // namespace clang
+
 Expected<TypeSourceInfo *> ASTImporter::Import(TypeSourceInfo *FromTSI) {
   if (!FromTSI)
     return FromTSI;
 
-  // FIXME: For now we just create a "trivial" type source info based
-  // on the type and a single location. Implement a real version of this.
   ExpectedType TOrErr = Import(FromTSI->getType());
   if (!TOrErr)
     return TOrErr.takeError();
-  ExpectedSLoc BeginLocOrErr = Import(FromTSI->getTypeLoc().getBeginLoc());
-  if (!BeginLocOrErr)
-    return BeginLocOrErr.takeError();
 
-  return ToContext.getTrivialTypeSourceInfo(*TOrErr, *BeginLocOrErr);
+  /*if (Minimal) {
+    // For minimal import we do not want to visit other Decl nodes that may be
+    // encountered during the import of a non-trivial TypeSourceInfo.
+    // FIXME: This strategy can be improved by moving such checks into
+    // TypeLocImporter.
+    ExpectedSLoc BeginLocOrErr = Import(FromTSI->getTypeLoc().getBeginLoc());
+    if (!BeginLocOrErr)
+      return BeginLocOrErr.takeError();
+
+    return ToContext.getTrivialTypeSourceInfo(*TOrErr, *BeginLocOrErr);
+  }*/
+
+  TypeSourceInfo *ToTSI = ToContext.CreateTypeSourceInfo(*TOrErr);
+
+  TypeLoc FromL = FromTSI->getTypeLoc();
+  TypeLoc ToL = ToTSI->getTypeLoc();
+  while (FromL) {
+    assert(ToL && "Not consistent TypeSourceInfo");
+    TypeLocImporter Importer(*this, ToL);
+    if (Error Err = Importer.Visit(FromL))
+      return std::move(Err);
+    FromL = FromL.getNextTypeLoc();
+    ToL = ToL.getNextTypeLoc();
+  }
+
+  return ToTSI;
 }
 
 Expected<Attr *> ASTImporter::Import(const Attr *FromAttr) {

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8129,18 +8129,6 @@ Expected<TypeSourceInfo *> ASTImporter::Import(TypeSourceInfo *FromTSI) {
   if (!TOrErr)
     return TOrErr.takeError();
 
-  /*if (Minimal) {
-    // For minimal import we do not want to visit other Decl nodes that may be
-    // encountered during the import of a non-trivial TypeSourceInfo.
-    // FIXME: This strategy can be improved by moving such checks into
-    // TypeLocImporter.
-    ExpectedSLoc BeginLocOrErr = Import(FromTSI->getTypeLoc().getBeginLoc());
-    if (!BeginLocOrErr)
-      return BeginLocOrErr.takeError();
-
-    return ToContext.getTrivialTypeSourceInfo(*TOrErr, *BeginLocOrErr);
-  }*/
-
   TypeSourceInfo *ToTSI = ToContext.CreateTypeSourceInfo(*TOrErr);
 
   TypeLoc FromL = FromTSI->getTypeLoc();


### PR DESCRIPTION
A new `TypeLocImporter` is created to  import the `TypeLoc` values from `TypeSourceInfo`. The previous "trivial TypeSourceInfo" is replaced.