### PR TITLE
Improved use of IsStructuralMatch.

### DIFF
--- a/lib/AST/ASTStructuralEquivalence.cpp
+++ b/lib/AST/ASTStructuralEquivalence.cpp
@@ -1577,6 +1577,17 @@ bool StructuralEquivalenceContext::CheckKindSpecificEquivalence(
       // Enum/non-enum mismatch
       return false;
     }
+  } else if (auto *EC1 = dyn_cast<EnumConstantDecl>(D1)) {
+    if (auto *EC2 = dyn_cast<EnumConstantDecl>(D2)) {
+      const llvm::APSInt &Val1 = EC1->getInitVal();
+      const llvm::APSInt &Val2 = EC2->getInitVal();
+      if (Val1.isSigned() != Val2.isSigned() ||
+          Val1.getBitWidth() != Val2.getBitWidth() || Val1 != Val2)
+        return false;
+    } else {
+      // Kind mismatch
+      return false;
+    }
   } else if (const auto *Typedef1 = dyn_cast<TypedefNameDecl>(D1)) {
     if (const auto *Typedef2 = dyn_cast<TypedefNameDecl>(D2)) {
       if (!::IsStructurallyEquivalent(Typedef1->getIdentifier(),


### PR DESCRIPTION
Handling of `EnumConstantDecl` for structural equivalence was moved into `StructuralEquivalenceContext` from `ASTNodeImporter`, and a single function `isStructurallyEquivalent` for `Decl` is used. (This change should be small enough to be in a single commit, and is a refactoring only.)