### PR TITLE
Improved import of same repeated friend decl.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3286,6 +3286,38 @@ ExpectedDecl ASTNodeImporter::VisitIndirectFieldDecl(IndirectFieldDecl *D) {
   return ToIndirectField;
 }
 
+static std::tuple<unsigned int, unsigned int>
+getFriendCountAndPosition(FriendDecl *FD) {
+  unsigned int FriendCount = 0;
+  llvm::Optional<unsigned int> FriendPosition;
+  auto *RD = cast<CXXRecordDecl>(FD->getLexicalDeclContext());
+  if (FD->getFriendType()) {
+    QualType TypeOfFriend = FD->getFriendType()->getType().getCanonicalType();
+    for (FriendDecl *FoundFriend : RD->friends()) {
+      if (FoundFriend == FD) {
+        FriendPosition = FriendCount;
+        ++FriendCount;
+      } else if (FoundFriend->getFriendType() &&
+                 FoundFriend->getFriendType()->getType().getCanonicalType() ==
+                     TypeOfFriend)
+        ++FriendCount;
+    }
+  } else {
+    const Decl *CanDeclOfFriend = FD->getFriendDecl()->getCanonicalDecl();
+    for (FriendDecl *FoundFriend : RD->friends()) {
+      if (FoundFriend == FD) {
+        FriendPosition = FriendCount;
+        ++FriendCount;
+      } else if (FoundFriend->getFriendDecl() &&
+                 FoundFriend->getFriendDecl()->getCanonicalDecl() ==
+                     CanDeclOfFriend)
+        ++FriendCount;
+    }
+  }
+  assert(FriendPosition && "Friend decl not found in own parent.");
+  return std::make_tuple(FriendCount, *FriendPosition);
+}
+
 ExpectedDecl ASTNodeImporter::VisitFriendDecl(FriendDecl *D) {
   // Import the major distinguishing characteristics of a declaration.
   DeclContext *DC, *LexicalDC;
@@ -3294,25 +3326,37 @@ ExpectedDecl ASTNodeImporter::VisitFriendDecl(FriendDecl *D) {
 
   // Determine whether we've already imported this decl.
   // FriendDecl is not a NamedDecl so we cannot use lookup.
+  // We try to maintain order and count of redundant friend declarations.
   auto *RD = cast<CXXRecordDecl>(DC);
   FriendDecl *ImportedFriend = RD->getFirstFriend();
+  SmallVector<FriendDecl *, 2> ImportedFriends;
 
   while (ImportedFriend) {
+    // FIXME: Can we not use isStructuralMatch only?
+    bool Match = false;
     if (D->getFriendDecl() && ImportedFriend->getFriendDecl()) {
-      if (isStructuralMatch(D->getFriendDecl(), ImportedFriend->getFriendDecl(),
-                            /*Complain=*/false))
-        return Importer.MapImported(D, ImportedFriend);
-
+      Match =
+          isStructuralMatch(D->getFriendDecl(), ImportedFriend->getFriendDecl(),
+                            /*Complain=*/false);
     } else if (D->getFriendType() && ImportedFriend->getFriendType()) {
-      if (Importer.IsStructurallyEquivalent(
-            D->getFriendType()->getType(),
-            ImportedFriend->getFriendType()->getType(), true))
-        return Importer.MapImported(D, ImportedFriend);
+      Match = Importer.IsStructurallyEquivalent(
+          D->getFriendType()->getType(),
+          ImportedFriend->getFriendType()->getType(), /*Complain=*/false);
     }
+    if (Match)
+      ImportedFriends.push_back(ImportedFriend);
+
     ImportedFriend = ImportedFriend->getNextFriend();
   }
+  std::tuple<unsigned int, unsigned int> CountAndPosition =
+      getFriendCountAndPosition(D);
+  if (ImportedFriends.size() >= std::get<0>(CountAndPosition))
+    return Importer.MapImported(D,
+                                ImportedFriends[std::get<1>(CountAndPosition)]);
+  // FIXME: Strict '>' above may indicate problem.
 
   // Not found. Create it.
+  // The declarations will be put into order later by ImportDeclContext.
   FriendDecl::FriendUnion ToFU;
   if (NamedDecl *FriendD = D->getFriendDecl()) {
     NamedDecl *ToFriendD;

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -3335,6 +3335,56 @@ TEST_P(ImportFriendClasses, ImportOfRecursiveFriendClass) {
   EXPECT_TRUE(MatchVerifier<Decl>{}.match(ToD, Pattern));
 }
 
+TEST_P(ImportFriendClasses, ImportOfRepeatedFriendType) {
+  auto Code =
+      R"(
+      class Container {
+        friend class X;
+        friend class X;
+      };
+      )";
+  Decl *ToTu = getToTuDecl(Code, Lang_CXX);
+  Decl *FromTu = getTuDecl(Code, Lang_CXX, "from.cc");
+
+  auto *ToFriend1 = FirstDeclMatcher<FriendDecl>().match(ToTu, friendDecl());
+  auto *ToFriend2 = LastDeclMatcher<FriendDecl>().match(ToTu, friendDecl());
+  auto *FromFriend1 =
+      FirstDeclMatcher<FriendDecl>().match(FromTu, friendDecl());
+  auto *FromFriend2 = LastDeclMatcher<FriendDecl>().match(FromTu, friendDecl());
+
+  FriendDecl *ToImportedFriend1 = Import(FromFriend1, Lang_CXX);
+  FriendDecl *ToImportedFriend2 = Import(FromFriend2, Lang_CXX);
+
+  EXPECT_NE(ToImportedFriend1, ToImportedFriend2);
+  EXPECT_EQ(ToFriend1, ToImportedFriend1);
+  EXPECT_EQ(ToFriend2, ToImportedFriend2);
+}
+
+TEST_P(ImportFriendClasses, ImportOfRepeatedFriendDecl) {
+  auto Code =
+      R"(
+      class Container {
+        friend void f();
+        friend void f();
+      };
+      )";
+  Decl *ToTu = getToTuDecl(Code, Lang_CXX);
+  Decl *FromTu = getTuDecl(Code, Lang_CXX, "from.cc");
+
+  auto *ToFriend1 = FirstDeclMatcher<FriendDecl>().match(ToTu, friendDecl());
+  auto *ToFriend2 = LastDeclMatcher<FriendDecl>().match(ToTu, friendDecl());
+  auto *FromFriend1 =
+      FirstDeclMatcher<FriendDecl>().match(FromTu, friendDecl());
+  auto *FromFriend2 = LastDeclMatcher<FriendDecl>().match(FromTu, friendDecl());
+
+  FriendDecl *ToImportedFriend1 = Import(FromFriend1, Lang_CXX);
+  FriendDecl *ToImportedFriend2 = Import(FromFriend2, Lang_CXX);
+
+  EXPECT_NE(ToImportedFriend1, ToImportedFriend2);
+  EXPECT_EQ(ToFriend1, ToImportedFriend1);
+  EXPECT_EQ(ToFriend2, ToImportedFriend2);
+}
+
 TEST_P(ImportFriendClasses, ImportOfRecursiveFriendClassTemplate) {
   Decl *FromTu = getTuDecl(
       R"(

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -772,6 +772,20 @@ TEST_F(StructuralEquivalenceRecordTest, RecordsWithDifferentBody) {
   EXPECT_FALSE(testStructuralMatch(t));
 }
 
+TEST_F(StructuralEquivalenceRecordTest, SameFriendMultipleTimes) {
+  auto t = makeNamedDecls("struct foo{ friend class X; };",
+                          "struct foo{ friend class X; friend class X; };",
+                          Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceRecordTest, SameFriendsDifferentOrder) {
+  auto t = makeNamedDecls("struct foo{ friend class X; friend class Y; };",
+                          "struct foo{ friend class Y; friend class X; };",
+                          Lang_CXX);
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
 TEST_F(StructuralEquivalenceTest, CompareSameDeclWithMultiple) {
   auto t = makeNamedDecls(
       "struct A{ }; struct B{ }; void foo(A a, A b);",


### PR DESCRIPTION
This does not fix known problem but was discovered during bug-fix.
It is valid to have friends like:
```
class X {
  friend class Y;
  friend class Y;
};
```
`ASTImporter` did not handle this case correctly, the friends were merged always. This causes later other problems: `ImportDeclContext` has a code to put the declarations into original order, this does not work if multiple declarations in _From_ context are merged into one in the _To_ (in the same DeclContext). The structural equivalence fails if the number or order of friend declarations is different, new tests were added for this.