### PR TITLE
Mark erroneous nodes in shared st

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -34,7 +34,7 @@
 namespace clang {
 
 class ASTContext;
-class ASTImporterLookupTable;
+class ASTImporterSharedState;
 class Attr;
 class CXXBaseSpecifier;
 class CXXCtorInitializer;
@@ -114,12 +114,7 @@ class TypeSourceInfo;
 
   private:
 
-    /// Pointer to the import specific lookup table, which may be shared
-    /// amongst several ASTImporter objects.
-    /// This is an externally managed resource (and should exist during the
-    /// lifetime of the ASTImporter object)
-    /// If not set then the original C/C++ lookup is used.
-    ASTImporterLookupTable *LookupTable = nullptr;
+    ASTImporterSharedState *SharedState = nullptr;
 
     /// The path which we go through during the import of a given AST node.
     ImportPathTy ImportPath;
@@ -202,7 +197,7 @@ class TypeSourceInfo;
     ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
                 ASTContext &FromContext, FileManager &FromFileManager,
                 bool MinimalImport,
-                ASTImporterLookupTable *LookupTable = nullptr);
+                ASTImporterSharedState *SharedState = nullptr);
 
     virtual ~ASTImporter();
 

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -113,8 +113,7 @@ class TypeSourceInfo;
     };
 
   private:
-
-    ASTImporterSharedState *SharedState = nullptr;
+    std::shared_ptr<ASTImporterSharedState> SharedState = nullptr;
 
     /// The path which we go through during the import of a given AST node.
     ImportPathTy ImportPath;
@@ -197,7 +196,7 @@ class TypeSourceInfo;
     ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
                 ASTContext &FromContext, FileManager &FromFileManager,
                 bool MinimalImport,
-                ASTImporterSharedState *SharedState = nullptr);
+                std::shared_ptr<ASTImporterSharedState> SharedState = nullptr);
 
     virtual ~ASTImporter();
 

--- a/include/clang/AST/ASTImporterSharedState.h
+++ b/include/clang/AST/ASTImporterSharedState.h
@@ -1,0 +1,65 @@
+//===- ASTImporterSharedState.h - ASTImporter specific state --*- C++ -*---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the ASTImporter specific state, which may be shared
+//  amongst several ASTImporter objects.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_AST_ASTIMPORTERSHAREDSTATE_H
+#define LLVM_CLANG_AST_ASTIMPORTERSHAREDSTATE_H
+
+#include "clang/AST/ASTImporterLookupTable.h"
+#include "llvm/ADT/DenseMap.h"
+// FIXME We need this because of ImportError.
+#include "clang/AST/ASTImporter.h"
+
+namespace clang {
+
+class TranslationUnitDecl;
+
+/// Importer specific state, which may be shared amongst several ASTImporter
+/// objects.
+class ASTImporterSharedState {
+
+  /// Pointer to the import specific lookup table.  This is an externally
+  /// managed resource (and should exist during the lifetime of the
+  /// ASTImporter object) If not set then the original C/C++ lookup is used.
+  ASTImporterLookupTable LookupTable;
+
+  /// Mapping from the already-imported declarations in the "to"
+  /// context to the error status of the import of that declaration.
+  /// This map contains only the declarations that were not correctly
+  /// imported. The same declaration may or may not be included in
+  /// ImportedFromDecls. This map is updated continuously during imports and
+  /// never cleared (like ImportedFromDecls).
+  llvm::DenseMap<Decl *, ImportError> ImportErrors;
+
+  // FIXME put ImportedFromDecls here!
+  // And from that point we can better encapsulate the lookup table.
+
+public:
+  ASTImporterSharedState(TranslationUnitDecl &ToTU) : LookupTable(ToTU) {}
+  ASTImporterLookupTable &getLookupTable() { return LookupTable; }
+
+  llvm::Optional<ImportError> getImportDeclErrorIfAny(Decl *ToD) const {
+    auto Pos = ImportErrors.find(ToD);
+    if (Pos != ImportErrors.end())
+      return Pos->second;
+    else
+      return Optional<ImportError>();
+  }
+
+  void setImportDeclError(Decl *To, ImportError Error) {
+    ImportErrors[To] = Error;
+  }
+};
+
+} // namespace clang
+#endif // LLVM_CLANG_AST_ASTIMPORTERSHAREDSTATE_H

--- a/include/clang/AST/ASTImporterSharedState.h
+++ b/include/clang/AST/ASTImporterSharedState.h
@@ -28,10 +28,8 @@ class TranslationUnitDecl;
 /// objects.
 class ASTImporterSharedState {
 
-  /// Pointer to the import specific lookup table.  This is an externally
-  /// managed resource (and should exist during the lifetime of the
-  /// ASTImporter object) If not set then the original C/C++ lookup is used.
-  ASTImporterLookupTable LookupTable;
+  /// Pointer to the import specific lookup table.
+  std::unique_ptr<ASTImporterLookupTable> LookupTable;
 
   /// Mapping from the already-imported declarations in the "to"
   /// context to the error status of the import of that declaration.
@@ -45,8 +43,13 @@ class ASTImporterSharedState {
   // And from that point we can better encapsulate the lookup table.
 
 public:
-  ASTImporterSharedState(TranslationUnitDecl &ToTU) : LookupTable(ToTU) {}
-  ASTImporterLookupTable &getLookupTable() { return LookupTable; }
+  ASTImporterSharedState() {}
+
+  ASTImporterSharedState(TranslationUnitDecl &ToTU) {
+    LookupTable = llvm::make_unique<ASTImporterLookupTable>(ToTU);
+  }
+
+  ASTImporterLookupTable *getLookupTable() { return LookupTable.get(); }
 
   llvm::Optional<ImportError> getImportDeclErrorIfAny(Decl *ToD) const {
     auto Pos = ImportErrors.find(ToD);

--- a/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/include/clang/CrossTU/CrossTranslationUnit.h
@@ -15,7 +15,7 @@
 #ifndef LLVM_CLANG_CROSSTU_CROSSTRANSLATIONUNIT_H
 #define LLVM_CLANG_CROSSTU_CROSSTRANSLATIONUNIT_H
 
-#include "clang/AST/ASTImporterLookupTable.h"
+#include "clang/AST/ASTImporterSharedState.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -144,7 +144,7 @@ public:
   void emitCrossTUDiagnostics(const IndexError &IE);
 
 private:
-  void lazyInitLookupTable(TranslationUnitDecl *ToTU);
+  void lazyInitASTImporterSharedState(TranslationUnitDecl *ToTU);
   ASTImporter &getOrCreateASTImporter(ASTContext &From);
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,
                                                 StringRef LookupFnName);
@@ -156,7 +156,7 @@ private:
       ASTUnitImporterMap;
   CompilerInstance &CI;
   ASTContext &Context;
-  std::unique_ptr<ASTImporterLookupTable> LookupTable;
+  std::shared_ptr<ASTImporterSharedState> ImporterSharedSt;
 };
 
 } // namespace cross_tu

--- a/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/include/clang/CrossTU/CrossTranslationUnit.h
@@ -144,7 +144,7 @@ public:
   void emitCrossTUDiagnostics(const IndexError &IE);
 
 private:
-  void lazyInitASTImporterSharedState(TranslationUnitDecl *ToTU);
+  void lazyInitImporterSharedSt(TranslationUnitDecl *ToTU);
   ASTImporter &getOrCreateASTImporter(ASTContext &From);
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,
                                                 StringRef LookupFnName);

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8005,6 +8005,10 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
   // Check whether we've already imported this declaration.
   Decl *ToD = GetAlreadyImportedOrNull(FromD);
   if (ToD) {
+    // Already imported (possibly from another TU) and with an error.
+    if (auto Error = SharedState->getImportDeclErrorIfAny(ToD))
+      return make_error<ImportError>(*Error);
+
     // If FromD has some updated flags after last import, apply it
     updateFlags(FromD, ToD);
     // If we encounter a cycle during an import then we save the relevant part
@@ -8054,12 +8058,20 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
       handleAllErrors(ToDOrErr.takeError(),
                       [&ErrOut](const ImportError &E) { ErrOut = E; });
       setImportDeclError(FromD, ErrOut);
+      // Set the error for the mapped to Decl, which is in the "to" context.
+      if (Pos != ImportedDecls.end())
+        SharedState->setImportDeclError(Pos->second, ErrOut);
 
       // Set the error for all nodes which have been created before we
       // recognized the error.
       for (const auto &Path : SavedImportPaths[FromD])
-        for (Decl *Di : Path)
-          setImportDeclError(Di, ErrOut);
+        for (Decl *FromDi : Path) {
+          setImportDeclError(FromDi, ErrOut);
+          // Set the error for the mapped to Decl, which is in the "to" context.
+          auto Ii = ImportedDecls.find(FromDi);
+          if (Ii != ImportedDecls.end())
+            SharedState->setImportDeclError(Ii->second, ErrOut);
+        }
       SavedImportPaths[FromD].clear();
 
       // Do not return ToDOrErr, error was taken out of it.
@@ -8079,6 +8091,11 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
     assert(Err);
     return make_error<ImportError>(*Err);
   }
+
+  // We could import from the current TU without error.  But previously we
+  // already had imported a Decl as `ToD` from another TU and with an error.
+  if (auto Error = SharedState->getImportDeclErrorIfAny(ToD))
+    return make_error<ImportError>(*Error);
 
   // Notify subclasses.
   Imported(FromD, ToD);

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/ASTImporter.h"
-#include "clang/AST/ASTImporterLookupTable.h"
+#include "clang/AST/ASTImporterSharedState.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTDiagnostic.h"
 #include "clang/AST/ASTStructuralEquivalence.h"
@@ -7509,8 +7509,8 @@ void ASTNodeImporter::ImportOverrides(CXXMethodDecl *ToMethod,
 ASTImporter::ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
                          ASTContext &FromContext, FileManager &FromFileManager,
                          bool MinimalImport,
-                         ASTImporterLookupTable *LookupTable)
-    : LookupTable(LookupTable), ToContext(ToContext), FromContext(FromContext),
+                         ASTImporterSharedState *SharedState)
+    : SharedState(SharedState), ToContext(ToContext), FromContext(FromContext),
       ToFileManager(ToFileManager), FromFileManager(FromFileManager),
       Minimal(MinimalImport) {
 
@@ -7552,9 +7552,9 @@ ASTImporter::findDeclsInToCtx(DeclContext *DC, DeclarationName Name) {
   // then the enum constant 'A' and the variable 'A' violates ODR.
   // We can diagnose this only if we search in the redecl context.
   DeclContext *ReDC = DC->getRedeclContext();
-  if (LookupTable) {
+  if (SharedState) {
     ASTImporterLookupTable::LookupResult LookupResult =
-        LookupTable->lookup(ReDC, Name);
+        SharedState->getLookupTable().lookup(ReDC, Name);
     return FoundDeclsTy(LookupResult.begin(), LookupResult.end());
   } else {
     // FIXME Can we remove this kind of lookup?
@@ -7566,9 +7566,9 @@ ASTImporter::findDeclsInToCtx(DeclContext *DC, DeclarationName Name) {
 }
 
 void ASTImporter::AddToLookupTable(Decl *ToD) {
-  if (LookupTable)
+  if (SharedState)
     if (auto *ToND = dyn_cast<NamedDecl>(ToD))
-      LookupTable->add(ToND);
+      SharedState->getLookupTable().add(ToND);
 }
 
 Expected<QualType> ASTImporter::Import(QualType FromT) {
@@ -8033,9 +8033,9 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
       // traverse of the 'to' context).
       auto PosF = ImportedFromDecls.find(ToD);
       if (PosF != ImportedFromDecls.end()) {
-        if (LookupTable)
+        if (SharedState)
           if (auto *ToND = dyn_cast<NamedDecl>(ToD))
-            LookupTable->remove(ToND);
+            SharedState->getLookupTable().remove(ToND);
         ImportedFromDecls.erase(PosF);
       }
 

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8049,6 +8049,8 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
       }
 
       // FIXME: AST may contain remaining references to the failed object.
+      // However, the ImportDeclErrors in the shared state contains all the
+      // failed objects together with their error.
     }
 
     if (!getImportDeclErrorIfAny(FromD)) {
@@ -8093,7 +8095,8 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
   }
 
   // We could import from the current TU without error.  But previously we
-  // already had imported a Decl as `ToD` from another TU and with an error.
+  // already had imported a Decl as `ToD` from another TU (with another
+  // ASTImporter object) and with an error.
   if (auto Error = SharedState->getImportDeclErrorIfAny(ToD))
     return make_error<ImportError>(*Error);
 

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -382,10 +382,10 @@ CrossTranslationUnitContext::importDefinition(const FunctionDecl *FD) {
   return ToDecl;
 }
 
-void CrossTranslationUnitContext::lazyInitLookupTable(
+void CrossTranslationUnitContext::lazyInitASTImporterSharedState(
     TranslationUnitDecl *ToTU) {
-  if (!LookupTable)
-    LookupTable = llvm::make_unique<ASTImporterLookupTable>(*ToTU);
+  if (!ImporterSharedSt)
+    ImporterSharedSt = llvm::make_unique<ASTImporterSharedState>(*ToTU);
 }
 
 ASTImporter &
@@ -393,10 +393,10 @@ CrossTranslationUnitContext::getOrCreateASTImporter(ASTContext &From) {
   auto I = ASTUnitImporterMap.find(From.getTranslationUnitDecl());
   if (I != ASTUnitImporterMap.end())
     return *I->second;
-  lazyInitLookupTable(Context.getTranslationUnitDecl());
+  lazyInitASTImporterSharedState(Context.getTranslationUnitDecl());
   ASTImporter *NewImporter = new ASTImporter(
       Context, Context.getSourceManager().getFileManager(), From,
-      From.getSourceManager().getFileManager(), false, LookupTable.get());
+      From.getSourceManager().getFileManager(), false, ImporterSharedSt);
   ASTUnitImporterMap[From.getTranslationUnitDecl()].reset(NewImporter);
   return *NewImporter;
 }

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -382,10 +382,10 @@ CrossTranslationUnitContext::importDefinition(const FunctionDecl *FD) {
   return ToDecl;
 }
 
-void CrossTranslationUnitContext::lazyInitASTImporterSharedState(
+void CrossTranslationUnitContext::lazyInitImporterSharedSt(
     TranslationUnitDecl *ToTU) {
   if (!ImporterSharedSt)
-    ImporterSharedSt = llvm::make_unique<ASTImporterSharedState>(*ToTU);
+    ImporterSharedSt = std::make_shared<ASTImporterSharedState>(*ToTU);
 }
 
 ASTImporter &
@@ -393,7 +393,7 @@ CrossTranslationUnitContext::getOrCreateASTImporter(ASTContext &From) {
   auto I = ASTUnitImporterMap.find(From.getTranslationUnitDecl());
   if (I != ASTUnitImporterMap.end())
     return *I->second;
-  lazyInitASTImporterSharedState(Context.getTranslationUnitDecl());
+  lazyInitImporterSharedSt(Context.getTranslationUnitDecl());
   ASTImporter *NewImporter = new ASTImporter(
       Context, Context.getSourceManager().getFileManager(), From,
       From.getSourceManager().getFileManager(), false, ImporterSharedSt);

--- a/lib/Frontend/ASTMerge.cpp
+++ b/lib/Frontend/ASTMerge.cpp
@@ -10,7 +10,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTDiagnostic.h"
 #include "clang/AST/ASTImporter.h"
-#include "clang/AST/ASTImporterLookupTable.h"
+#include "clang/AST/ASTImporterSharedState.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
@@ -39,7 +39,7 @@ void ASTMergeAction::ExecuteAction() {
                                        &CI.getASTContext());
   IntrusiveRefCntPtr<DiagnosticIDs>
       DiagIDs(CI.getDiagnostics().getDiagnosticIDs());
-  ASTImporterLookupTable LookupTable(
+  ASTImporterSharedState SharedState(
       *CI.getASTContext().getTranslationUnitDecl());
   for (unsigned I = 0, N = ASTFiles.size(); I != N; ++I) {
     IntrusiveRefCntPtr<DiagnosticsEngine>
@@ -56,7 +56,7 @@ void ASTMergeAction::ExecuteAction() {
 
     ASTImporter Importer(CI.getASTContext(), CI.getFileManager(),
                          Unit->getASTContext(), Unit->getFileManager(),
-                         /*MinimalImport=*/false, &LookupTable);
+                         /*MinimalImport=*/false, &SharedState);
 
     TranslationUnitDecl *TU = Unit->getASTContext().getTranslationUnitDecl();
     for (auto *D : TU->decls()) {

--- a/lib/Frontend/ASTMerge.cpp
+++ b/lib/Frontend/ASTMerge.cpp
@@ -39,7 +39,7 @@ void ASTMergeAction::ExecuteAction() {
                                        &CI.getASTContext());
   IntrusiveRefCntPtr<DiagnosticIDs>
       DiagIDs(CI.getDiagnostics().getDiagnosticIDs());
-  ASTImporterSharedState SharedState(
+  auto SharedState = std::make_shared<ASTImporterSharedState>(
       *CI.getASTContext().getTranslationUnitDecl());
   for (unsigned I = 0, N = ASTFiles.size(); I != N; ++I) {
     IntrusiveRefCntPtr<DiagnosticsEngine>
@@ -56,7 +56,7 @@ void ASTMergeAction::ExecuteAction() {
 
     ASTImporter Importer(CI.getASTContext(), CI.getFileManager(),
                          Unit->getASTContext(), Unit->getFileManager(),
-                         /*MinimalImport=*/false, &SharedState);
+                         /*MinimalImport=*/false, SharedState);
 
     TranslationUnitDecl *TU = Unit->getASTContext().getTranslationUnitDecl();
     for (auto *D : TU->decls()) {

--- a/unittests/AST/ASTImporterFixtures.cpp
+++ b/unittests/AST/ASTImporterFixtures.cpp
@@ -115,7 +115,8 @@ ASTImporterTestBase::TU::TU(StringRef Code, StringRef FileName, ArgVector Args)
 }
 
 void ASTImporterTestBase::TU::lazyInitImporter(
-    std::shared_ptr<ASTImporterSharedState> &SharedState, ASTUnit *ToAST) {
+    const std::shared_ptr<ASTImporterSharedState> &SharedState,
+    ASTUnit *ToAST) {
   assert(ToAST);
   if (!Importer) {
     Importer.reset(new ASTImporter(
@@ -127,7 +128,7 @@ void ASTImporterTestBase::TU::lazyInitImporter(
 }
 
 Decl *ASTImporterTestBase::TU::import(
-    std::shared_ptr<ASTImporterSharedState> &SharedState, ASTUnit *ToAST,
+    const std::shared_ptr<ASTImporterSharedState> &SharedState, ASTUnit *ToAST,
     Decl *FromDecl) {
   lazyInitImporter(SharedState, ToAST);
   if (auto ImportedOrErr = Importer->Import(FromDecl))
@@ -139,7 +140,7 @@ Decl *ASTImporterTestBase::TU::import(
 }
 
 QualType ASTImporterTestBase::TU::import(
-    std::shared_ptr<ASTImporterSharedState> &SharedState, ASTUnit *ToAST,
+    const std::shared_ptr<ASTImporterSharedState> &SharedState, ASTUnit *ToAST,
     QualType FromType) {
   lazyInitImporter(SharedState, ToAST);
   if (auto ImportedOrErr = Importer->Import(FromType))

--- a/unittests/AST/ASTImporterFixtures.h
+++ b/unittests/AST/ASTImporterFixtures.h
@@ -86,11 +86,12 @@ class ASTImporterTestBase : public CompilerOptionSpecificTest {
     std::unique_ptr<ASTImporter> Importer;
 
     TU(StringRef Code, StringRef FileName, ArgVector Args);
-    void lazyInitImporter(ASTImporterSharedState &SharedState, ASTUnit *ToAST);
-    Decl *import(ASTImporterSharedState &SharedState, ASTUnit *ToAST,
-                 Decl *FromDecl);
-    QualType import(ASTImporterSharedState &SharedState, ASTUnit *ToAST,
-                    QualType FromType);
+    void lazyInitImporter(std::shared_ptr<ASTImporterSharedState> &SharedState,
+                          ASTUnit *ToAST);
+    Decl *import(std::shared_ptr<ASTImporterSharedState> &SharedState,
+                 ASTUnit *ToAST, Decl *FromDecl);
+    QualType import(std::shared_ptr<ASTImporterSharedState> &SharedState,
+                    ASTUnit *ToAST, QualType FromType);
     ~TU();
   };
 
@@ -111,7 +112,7 @@ class ASTImporterTestBase : public CompilerOptionSpecificTest {
   TU *findFromTU(Decl *From);
 
 protected:
-  std::unique_ptr<ASTImporterSharedState> SharedStatePtr;
+  std::shared_ptr<ASTImporterSharedState> SharedStatePtr;
 
 public:
   // We may have several From context but only one To context.

--- a/unittests/AST/ASTImporterFixtures.h
+++ b/unittests/AST/ASTImporterFixtures.h
@@ -13,7 +13,7 @@
 
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/AST/ASTImporter.h"
-#include "clang/AST/ASTImporterLookupTable.h"
+#include "clang/AST/ASTImporterSharedState.h"
 
 #include "DeclMatcher.h"
 #include "Language.h"
@@ -21,7 +21,7 @@
 namespace clang {
 
 class ASTImporter;
-class ASTImporterLookupTable;
+class ASTImporterSharedState;
 class ASTUnit;
 
 namespace ast_matchers {
@@ -86,10 +86,10 @@ class ASTImporterTestBase : public CompilerOptionSpecificTest {
     std::unique_ptr<ASTImporter> Importer;
 
     TU(StringRef Code, StringRef FileName, ArgVector Args);
-    void lazyInitImporter(ASTImporterLookupTable &LookupTable, ASTUnit *ToAST);
-    Decl *import(ASTImporterLookupTable &LookupTable, ASTUnit *ToAST,
+    void lazyInitImporter(ASTImporterSharedState &SharedState, ASTUnit *ToAST);
+    Decl *import(ASTImporterSharedState &SharedState, ASTUnit *ToAST,
                  Decl *FromDecl);
-    QualType import(ASTImporterLookupTable &LookupTable, ASTUnit *ToAST,
+    QualType import(ASTImporterSharedState &SharedState, ASTUnit *ToAST,
                     QualType FromType);
     ~TU();
   };
@@ -103,15 +103,15 @@ class ASTImporterTestBase : public CompilerOptionSpecificTest {
   // vector is expanding, with the list we won't have these issues.
   std::list<TU> FromTUs;
 
-  // Initialize the lookup table if not initialized already.
-  void lazyInitLookupTable(TranslationUnitDecl *ToTU);
+  // Initialize the shared state if not initialized already.
+  void lazyInitSharedState(TranslationUnitDecl *ToTU);
 
   void lazyInitToAST(Language ToLang, StringRef ToSrcCode, StringRef FileName);
 
   TU *findFromTU(Decl *From);
 
 protected:
-  std::unique_ptr<ASTImporterLookupTable> LookupTablePtr;
+  std::unique_ptr<ASTImporterSharedState> SharedStatePtr;
 
 public:
   // We may have several From context but only one To context.

--- a/unittests/AST/ASTImporterFixtures.h
+++ b/unittests/AST/ASTImporterFixtures.h
@@ -86,11 +86,12 @@ class ASTImporterTestBase : public CompilerOptionSpecificTest {
     std::unique_ptr<ASTImporter> Importer;
 
     TU(StringRef Code, StringRef FileName, ArgVector Args);
-    void lazyInitImporter(std::shared_ptr<ASTImporterSharedState> &SharedState,
-                          ASTUnit *ToAST);
-    Decl *import(std::shared_ptr<ASTImporterSharedState> &SharedState,
+    void
+    lazyInitImporter(const std::shared_ptr<ASTImporterSharedState> &SharedState,
+                     ASTUnit *ToAST);
+    Decl *import(const std::shared_ptr<ASTImporterSharedState> &SharedState,
                  ASTUnit *ToAST, Decl *FromDecl);
-    QualType import(std::shared_ptr<ASTImporterSharedState> &SharedState,
+    QualType import(const std::shared_ptr<ASTImporterSharedState> &SharedState,
                     ASTUnit *ToAST, QualType FromType);
     ~TU();
   };

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2665,7 +2665,7 @@ private:
       CXXMethodDecl *Method =
           FirstDeclMatcher<CXXMethodDecl>().match(ToClass, MethodMatcher);
       ToClass->removeDecl(Method);
-      SharedStatePtr->getLookupTable().remove(Method);
+      SharedStatePtr->getLookupTable()->remove(Method);
     }
 
     ASSERT_EQ(DeclCounter<CXXMethodDecl>().match(ToClass, MethodMatcher), 0u);

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2096,7 +2096,6 @@ TEST_P(ImportFunctions, ImportImplicitFunctionsInLambda) {
       FromTU, functionDecl(hasName("foo")));
   auto *ToD = Import(FromD, Lang_CXX);
   EXPECT_TRUE(ToD);
-  Decl *ToTU = ToAST->getASTContext().getTranslationUnitDecl();
   CXXRecordDecl *LambdaRec =
       cast<LambdaExpr>(cast<CStyleCastExpr>(
                            *cast<CompoundStmt>(ToD->getBody())->body_begin())
@@ -2666,7 +2665,7 @@ private:
       CXXMethodDecl *Method =
           FirstDeclMatcher<CXXMethodDecl>().match(ToClass, MethodMatcher);
       ToClass->removeDecl(Method);
-      LookupTablePtr->remove(Method);
+      SharedStatePtr->getLookupTable().remove(Method);
     }
 
     ASSERT_EQ(DeclCounter<CXXMethodDecl>().match(ToClass, MethodMatcher), 0u);


### PR DESCRIPTION
This is the second step of the full error handling. We store the errors for the Decls in the "to" context too. For that, however, we have to put these errors in a shared state (among all the ASTImporter objects).