### PR TITLE
TemplateName structural equivalence related fixes.

### DIFF
--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -970,6 +970,7 @@ template <template <typename PP1> class P1> class Templ {
   };
 };
 
+// Instantiate with substitution Arg into P1.
 template class Templ <Arg>;
       )",
       Lang_CXX, classTemplateSpecializationDecl(hasName("Primary")));
@@ -989,6 +990,7 @@ void f() {
 }
       )",
       R"(
+// Arg is different from the other, this should cause non-equivalence.
 template <typename P1> class Arg { int X; };
 template <template <typename PP1> class P1> class Primary { };
 
@@ -999,6 +1001,7 @@ template <template <typename PP1> class P1> class Templ {
   };
 };
 
+// Instantiate with substitution Arg into P1.
 template class Templ <Arg>;
       )",
       Lang_CXX, classTemplateSpecializationDecl(hasName("Primary")));

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -947,6 +947,64 @@ TEST_F(
   EXPECT_FALSE(testStructuralMatch(t));
 }
 
+TEST_F(StructuralEquivalenceTemplateTest,
+       TemplateVsSubstTemplateTemplateParmInArgEq) {
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
+      R"(
+template <typename P1> class Arg { };
+template <template <typename PP1> class P1> class Primary { };
+
+void f() {
+  // Make specialization with simple template.
+  Primary <Arg> A;
+}
+      )",
+      R"(
+template <typename P1> class Arg { };
+template <template <typename PP1> class P1> class Primary { };
+
+template <template <typename PP1> class P1> class Templ {
+  void f() {
+    // Make specialization with substituted template template param.
+    Primary <P1> A;
+  };
+};
+
+template class Templ <Arg>;
+      )",
+      Lang_CXX, classTemplateSpecializationDecl(hasName("Primary")));
+  EXPECT_TRUE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceTemplateTest,
+       TemplateVsSubstTemplateTemplateParmInArgNotEq) {
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
+      R"(
+template <typename P1> class Arg { };
+template <template <typename PP1> class P1> class Primary { };
+
+void f() {
+  // Make specialization with simple template.
+  Primary <Arg> A;
+}
+      )",
+      R"(
+template <typename P1> class Arg { int X; };
+template <template <typename PP1> class P1> class Primary { };
+
+template <template <typename PP1> class P1> class Templ {
+  void f() {
+    // Make specialization with substituted template template param.
+    Primary <P1> A;
+  };
+};
+
+template class Templ <Arg>;
+      )",
+      Lang_CXX, classTemplateSpecializationDecl(hasName("Primary")));
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
 struct StructuralEquivalenceDependentTemplateArgsTest
     : StructuralEquivalenceTemplateTest {};
 


### PR DESCRIPTION
Different kinds of `TemplateName` should be equal if the template decl (if available) is equal (even if the name kind is different).