### PR TITLE
[ASTImporter] Check visibility of EnumDecl.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2436,6 +2436,8 @@ ExpectedDecl ASTNodeImporter::VisitEnumDecl(EnumDecl *D) {
       }
 
       if (auto *FoundEnum = dyn_cast<EnumDecl>(FoundDecl)) {
+        if (!hasSameVisibilityContext(FoundEnum, D))
+          continue;
         if (isStructuralMatch(D, FoundEnum, true))
           return Importer.MapImported(D, FoundEnum);
         ConflictingDecls.push_back(FoundDecl);

--- a/unittests/AST/ASTImporterVisibilityTest.cpp
+++ b/unittests/AST/ASTImporterVisibilityTest.cpp
@@ -36,6 +36,10 @@ struct GetClassPattern {
   using DeclTy = CXXRecordDecl;
   BindableMatcher<Decl> operator()() { return cxxRecordDecl(hasName("X")); }
 };
+struct GetEnumPattern {
+  using DeclTy = EnumDecl;
+  BindableMatcher<Decl> operator()() { return enumDecl(hasName("E")); }
+};
 
 // Values for the value-parameterized test fixtures.
 // FunctionDecl:
@@ -49,6 +53,9 @@ auto *AnonV = "namespace { extern int v; }";
 // CXXRecordDecl:
 auto *ExternC = "class X;";
 auto *AnonC = "namespace { class X; }";
+// EnumDecl:
+auto *ExternE = "enum E {};";
+auto *AnonE = "namespace { enum E {}; }";
 
 // First value in tuple: Compile options.
 // Second value in tuple: Source code to be used in the test.
@@ -186,10 +193,53 @@ protected:
     else
       EXPECT_FALSE(ToF1->getPreviousDecl());
   }
+
+  void TypedTest_ImportAfterWithDef() {
+    TranslationUnitDecl *ToTu = getToTuDecl(getCode0(), Lang_CXX);
+    TranslationUnitDecl *FromTu = getTuDecl(getCode1(), Lang_CXX, "input1.cc");
+
+    auto *ToF0 = FirstDeclMatcher<DeclTy>().match(ToTu, getPattern());
+    auto *FromF1 = FirstDeclMatcher<DeclTy>().match(FromTu, getPattern());
+
+    auto *ToF1 = Import(FromF1, Lang_CXX);
+
+    ASSERT_TRUE(ToF0);
+    ASSERT_TRUE(ToF1);
+
+    if (shouldBeLinked())
+      EXPECT_EQ(ToF0, ToF1);
+    else
+      EXPECT_NE(ToF0, ToF1);
+
+    // We expect no (ODR) warning during the import.
+    EXPECT_EQ(0u, ToTu->getASTContext().getDiagnostics().getNumWarnings());
+  }
+
+  void TypedTest_ImportAfterImportWithDef() {
+    TranslationUnitDecl *FromTu0 = getTuDecl(getCode0(), Lang_CXX, "input0.cc");
+    TranslationUnitDecl *FromTu1 = getTuDecl(getCode1(), Lang_CXX, "input1.cc");
+    auto *FromF0 = FirstDeclMatcher<DeclTy>().match(FromTu0, getPattern());
+    auto *FromF1 = FirstDeclMatcher<DeclTy>().match(FromTu1, getPattern());
+    auto *ToF0 = Import(FromF0, Lang_CXX);
+    auto *ToF1 = Import(FromF1, Lang_CXX);
+    ASSERT_TRUE(ToF0);
+    ASSERT_TRUE(ToF1);
+    if (shouldBeLinked())
+      EXPECT_EQ(ToF0, ToF1);
+    else
+      EXPECT_NE(ToF0, ToF1);
+
+    // We expect no (ODR) warning during the import.
+    EXPECT_EQ(0u, ToF0->getTranslationUnitDecl()
+                      ->getASTContext()
+                      .getDiagnostics()
+                      .getNumWarnings());
+  }
 };
 using ImportFunctionsVisibility = ImportVisibility<GetFunPattern>;
 using ImportVariablesVisibility = ImportVisibility<GetVarPattern>;
 using ImportClassesVisibility = ImportVisibility<GetClassPattern>;
+using ImportEnumsVisibility = ImportVisibility<GetEnumPattern>;
 
 // FunctionDecl.
 TEST_P(ImportFunctionsVisibility, ImportAfter) {
@@ -211,6 +261,11 @@ TEST_P(ImportClassesVisibility, ImportAfter) {
 }
 TEST_P(ImportClassesVisibility, ImportAfterImport) {
   TypedTest_ImportAfterImport();
+}
+// EnumDecl.
+TEST_P(ImportEnumsVisibility, ImportAfter) { TypedTest_ImportAfterWithDef(); }
+TEST_P(ImportEnumsVisibility, ImportAfterImport) {
+  TypedTest_ImportAfterImportWithDef();
 }
 
 bool ExpectLink = true;
@@ -250,7 +305,14 @@ INSTANTIATE_TEST_CASE_P(
                           std::make_tuple(ExternC, AnonC, ExpectNotLink),
                           std::make_tuple(AnonC, ExternC, ExpectNotLink),
                           std::make_tuple(AnonC, AnonC, ExpectNotLink))), );
-
+INSTANTIATE_TEST_CASE_P(
+    ParameterizedTests, ImportEnumsVisibility,
+    ::testing::Combine(
+        DefaultTestValuesForRunOptions,
+        ::testing::Values(std::make_tuple(ExternE, ExternE, ExpectLink),
+                          std::make_tuple(ExternE, AnonE, ExpectNotLink),
+                          std::make_tuple(AnonE, ExternE, ExpectNotLink),
+                          std::make_tuple(AnonE, AnonE, ExpectNotLink))), );
 
 } // end namespace ast_matchers
 } // end namespace clang

--- a/unittests/AST/ASTImporterVisibilityTest.cpp
+++ b/unittests/AST/ASTImporterVisibilityTest.cpp
@@ -194,7 +194,7 @@ protected:
       EXPECT_FALSE(ToF1->getPreviousDecl());
   }
 
-  void TypedTest_ImportAfterWithDef() {
+  void TypedTest_ImportAfterWithMerge() {
     TranslationUnitDecl *ToTu = getToTuDecl(getCode0(), Lang_CXX);
     TranslationUnitDecl *FromTu = getTuDecl(getCode1(), Lang_CXX, "input1.cc");
 
@@ -215,7 +215,7 @@ protected:
     EXPECT_EQ(0u, ToTu->getASTContext().getDiagnostics().getNumWarnings());
   }
 
-  void TypedTest_ImportAfterImportWithDef() {
+  void TypedTest_ImportAfterImportWithMerge() {
     TranslationUnitDecl *FromTu0 = getTuDecl(getCode0(), Lang_CXX, "input0.cc");
     TranslationUnitDecl *FromTu1 = getTuDecl(getCode1(), Lang_CXX, "input1.cc");
     auto *FromF0 = FirstDeclMatcher<DeclTy>().match(FromTu0, getPattern());
@@ -263,9 +263,9 @@ TEST_P(ImportClassesVisibility, ImportAfterImport) {
   TypedTest_ImportAfterImport();
 }
 // EnumDecl.
-TEST_P(ImportEnumsVisibility, ImportAfter) { TypedTest_ImportAfterWithDef(); }
+TEST_P(ImportEnumsVisibility, ImportAfter) { TypedTest_ImportAfterWithMerge(); }
 TEST_P(ImportEnumsVisibility, ImportAfterImport) {
-  TypedTest_ImportAfterImportWithDef();
+  TypedTest_ImportAfterImportWithMerge();
 }
 
 bool ExpectLink = true;


### PR DESCRIPTION
Similar enum decls in different anonymous namespace were not handled correctly.
Added one unit test (maybe add for non-namespace vs namespace case too?), this discovered that the brace-range was not imported (SourceLocation check failure).