### PR TITLE
Enable the usage of ctu-import-threshold thru analyzer-config

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -343,6 +343,10 @@ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
         Success = false;
         break;
       }
+      if (key == "ctu-import-threshold") {
+        Opts.CTUImportThreshold = std::stoul(val);
+        continue;
+      }
       Opts.Config[key] = val;
     }
   }


### PR DESCRIPTION
As a quick-fix, the threshold is added as an analyzer-option. This part will be refactored heavily when we rebase onto the next clang version.