### PR TITLE
Added correct import of AlignedAttr.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8068,11 +8068,42 @@ Expected<TypeSourceInfo *> ASTImporter::Import(TypeSourceInfo *FromTSI) {
 }
 
 Expected<Attr *> ASTImporter::Import(const Attr *FromAttr) {
-  Attr *ToAttr = FromAttr->clone(ToContext);
-  if (auto ToRangeOrErr = Import(FromAttr->getRange()))
-    ToAttr->setRange(*ToRangeOrErr);
-  else
-    return ToRangeOrErr.takeError();
+  Attr *ToAttr = nullptr;
+  SourceRange ToRange;
+  if (Error Err = importInto(ToRange, FromAttr->getRange()))
+    return std::move(Err);
+
+  // FIXME: Does a AttrVisitor exist, instead of this switch?
+  switch (FromAttr->getKind()) {
+  case attr::Aligned: {
+    auto *From = cast<AlignedAttr>(FromAttr);
+    AlignedAttr *To;
+    if (From->isAlignmentExpr()) {
+      if (auto ToEOrErr = Import(From->getAlignmentExpr()))
+        To = new (ToContext) AlignedAttr(ToRange, ToContext, true, *ToEOrErr,
+                                         FromAttr->getSpellingListIndex());
+      else
+        return ToEOrErr.takeError();
+    } else {
+      if (auto ToTOrErr = Import(From->getAlignmentType()))
+        To = new (ToContext) AlignedAttr(ToRange, ToContext, false, *ToTOrErr,
+                                         FromAttr->getSpellingListIndex());
+      else
+        return ToTOrErr.takeError();
+    }
+    To->setInherited(From->isInherited());
+    To->setPackExpansion(From->isPackExpansion());
+    To->setImplicit(From->isImplicit());
+    ToAttr = To;
+    break;
+  }
+  default:
+    // FIXME: 'clone' copies every member but some of them should be imported.
+    // Handle other Attrs that have parameters that should be imported.
+    ToAttr = FromAttr->clone(ToContext);
+    ToAttr->setRange(ToRange);
+    break;
+  }
 
   return ToAttr;
 }

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4741,7 +4741,7 @@ TEST_P(ASTImporterOptionSpecificTestBase,
   ASSERT_NE(ToL0, ToL1);
 }
 
-TEST_P(ASTImporterOptionSpecificTestBase, ImportTypeOfAlignmentAttr) {
+TEST_P(ASTImporterOptionSpecificTestBase, ImportExprOfAlignmentAttr) {
   // FIXME: These packed and aligned attributes could trigger an error situation
   // where source location from 'From' context is referenced in 'To' context
   // through evaluation of the alignof attribute.
@@ -4758,6 +4758,14 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportTypeOfAlignmentAttr) {
 
   auto *ToD = Import(FromD, Lang_CXX11);
   ASSERT_TRUE(ToD);
+
+  auto *FromAttr = FromD->getAttr<AlignedAttr>();
+  auto *ToAttr = ToD->getAttr<AlignedAttr>();
+  EXPECT_EQ(FromAttr->isInherited(), ToAttr->isInherited());
+  EXPECT_EQ(FromAttr->isPackExpansion(), ToAttr->isPackExpansion());
+  EXPECT_EQ(FromAttr->isImplicit(), ToAttr->isImplicit());
+  EXPECT_TRUE(ToAttr->getAlignmentExpr());
+
   auto *ToA = FirstDeclMatcher<CXXRecordDecl>().match(
       ToD->getTranslationUnitDecl(),
       cxxRecordDecl(hasName("A"), unless(isImplicit())));


### PR DESCRIPTION
The import of AlignedAttr has caused crash during LLVM analysis ( #645 ), this problem was fixed. (Other kind of Attr should be fixed too.)