### PR TITLE
Warn if Decl is merged at import of DeclContext.

### DIFF
--- a/include/clang/Basic/DiagnosticASTKinds.td
+++ b/include/clang/Basic/DiagnosticASTKinds.td
@@ -355,4 +355,6 @@ def warn_odr_non_type_parameter_type_inconsistent : Warning<
 def err_unsupported_ast_node: Error<"cannot import unsupported AST node %0">;
 def warn_ast_importer_missing_decl_in_decl_context : Warning<
   "missing %0Decl in imported DeclContext <%1:%2:%3>">;
+def warn_ast_importer_merged_decl_in_decl_context : Warning<
+  "merged %0Decl in DeclContext from <%1:%2:%3> to <%4:%5:%6>">;
 }

--- a/include/clang/Basic/DiagnosticASTKinds.td
+++ b/include/clang/Basic/DiagnosticASTKinds.td
@@ -356,5 +356,5 @@ def err_unsupported_ast_node: Error<"cannot import unsupported AST node %0">;
 def warn_ast_importer_missing_decl_in_decl_context : Warning<
   "missing %0Decl in imported DeclContext <%1:%2:%3>">;
 def warn_ast_importer_merged_decl_in_decl_context : Warning<
-  "merged %0Decl in DeclContext from <%1:%2:%3> to <%4:%5:%6>">;
+  "%0Decl <%1:%2:%3> was mapped to <%4:%5:%6> at AST import">;
 }

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -1675,6 +1675,13 @@ ASTNodeImporter::ImportDeclarationNameLoc(
 }
 
 Error ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) {
+
+  auto GetPresumedLoc = [](Decl *D) {
+    const SourceManager &SM = D->getASTContext().getSourceManager();
+    SourceLocation Loc = SM.getSpellingLoc(D->getLocation());
+    return SM.getPresumedLoc(Loc);
+  };
+
   if (Importer.isMinimalImport() && !ForceImport) {
     auto ToDCOrErr = Importer.ImportContext(FromDC);
     return ToDCOrErr.takeError();
@@ -1692,7 +1699,8 @@ Error ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) 
   bool AccumulateChildErrors = isa<TagDecl>(FromDC);
 
   Error ChildErrors = Error::success();
-  llvm::SmallVector<Decl *, 8> ImportedDecls;
+  llvm::SmallVector<Decl *, 8> ImportedDeclsOriginalOrder;
+  llvm::DenseSet<Decl *> ImportedDecls;
   for (auto *From : FromDC->decls()) {
     ExpectedDecl ImportedOrErr = import(From);
     if (!ImportedOrErr) {
@@ -1702,7 +1710,21 @@ Error ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) 
       else
         consumeError(ImportedOrErr.takeError());
     } else {
-      ImportedDecls.push_back(*ImportedOrErr);
+      Decl *To = *ImportedOrErr;
+      assert(To && "FromDC->decls contained a nullptr?");
+      auto InsertResult = ImportedDecls.insert(To);
+      if (InsertResult.second) {
+        ImportedDeclsOriginalOrder.push_back(To);
+      } else if (!isa<NamespaceDecl>(To)) {
+        PresumedLoc FromPLoc = GetPresumedLoc(From);
+        PresumedLoc ToPLoc = GetPresumedLoc(To);
+
+        FromDC->getParentASTContext().getDiagnostics().Report(
+            diag::warn_ast_importer_merged_decl_in_decl_context)
+            << To->getDeclKindName() << FromPLoc.getFilename()
+            << FromPLoc.getLine() << FromPLoc.getColumn()
+            << ToPLoc.getFilename() << ToPLoc.getLine() << ToPLoc.getColumn();
+      }
     }
   }
 
@@ -1722,18 +1744,14 @@ Error ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) 
   llvm::SmallDenseSet<Decl *, 2> MissingDecls;
   // Frist, remove all declarations, which may be in wrong order in the
   // lexical DeclContext.
-  for (Decl *ToD : ImportedDecls) { // O(n)
-    if (ToD && ToD->getLexicalDeclContext() == ToDC) {
+  for (Decl *ToD : ImportedDeclsOriginalOrder) { // O(n)
+    if (ToD->getLexicalDeclContext() == ToDC) {
       if (ToDC->containsDecl(ToD)) { // containsDecl is O(1)
         ToDC->removeDecl(ToD);       // O(n)
       } else {
         MissingDecls.insert(ToD);
 
-        const SourceLocation &Loc = ToD->getLocation();
-        const SourceManager &SM = ToD->getASTContext().getSourceManager();
-        SourceLocation SpellingLoc = SM.getSpellingLoc(Loc);
-        PresumedLoc PLoc = SM.getPresumedLoc(SpellingLoc);
-
+        PresumedLoc PLoc = GetPresumedLoc(ToD);
         FromDC->getParentASTContext().getDiagnostics().Report(
             diag::warn_ast_importer_missing_decl_in_decl_context)
             << ToD->getDeclKindName() << PLoc.getFilename() << PLoc.getLine()
@@ -1742,8 +1760,8 @@ Error ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) 
     }
   }
   // Add the declarations, but this time in the correct order.
-  for (Decl *ToD : ImportedDecls) {
-    if (ToD && ToD->getLexicalDeclContext() == ToDC) {
+  for (Decl *ToD : ImportedDeclsOriginalOrder) {
+    if (ToD->getLexicalDeclContext() == ToDC) {
       // FIXME remove this if, when all Decls are properly imported
       if (MissingDecls.count(ToD) == 0) {
         ToDC->addDeclInternal(ToD);


### PR DESCRIPTION
Maintain "merged" imported Decls at import of contents of DeclContext (different **From** Decl was imported to same **To**). Old "missing Decl" warning is removed from this case, instead a new warning is added.