### PR TITLE
Check ODR hash at struct eq of Expr.

### DIFF
--- a/lib/AST/ASTStructuralEquivalence.cpp
+++ b/lib/AST/ASTStructuralEquivalence.cpp
@@ -76,6 +76,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/NestedNameSpecifier.h"
+#include "clang/AST/ODRHash.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
@@ -163,7 +164,15 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
     return IsStructurallyEquivalent(Context, DE1->getQualifier(),
                                     DE2->getQualifier());
   }
-  // FIXME: Handle other kind of expressions!
+  // FIXME: Handle other kind of expressions?
+
+  ODRHash H1, H2;
+  llvm::FoldingSetNodeID ID1, ID2;
+  E1->ProcessODRHash(ID1, H1);
+  E2->ProcessODRHash(ID2, H2);
+  if (ID1 != ID2)
+    return false;
+
   return true;
 }
 

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -4804,6 +4804,29 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportOfDefaultImplicitFunctions) {
   EXPECT_EQ(ToD1->getCanonicalDecl(), ToD2->getCanonicalDecl());
 }
 
+TEST_P(ASTImporterOptionSpecificTestBase, ImportOfFriendTemplateWithArgExpr) {
+  auto Code =
+      R"(
+        template <bool B1, bool B2>
+        struct X { 
+          friend X<B1, !B2>;
+          friend X<!B1, B2>;
+        };
+        )";
+
+  Decl *FromTU = getTuDecl(Code, Lang_CXX11, "input.cc");
+  auto *FromD1 = FirstDeclMatcher<FriendDecl>().match(FromTU, friendDecl());
+  auto *FromD2 = LastDeclMatcher<FriendDecl>().match(FromTU, friendDecl());
+
+  auto *ToD1 = Import(FromD1, Lang_CXX11);
+  ASSERT_TRUE(ToD1);
+
+  auto *ToD2 = Import(FromD2, Lang_CXX11);
+  ASSERT_TRUE(ToD2);
+
+  EXPECT_NE(ToD1->getCanonicalDecl(), ToD2->getCanonicalDecl());
+}
+
 INSTANTIATE_TEST_CASE_P(ParameterizedTests, ASTImporterLookupTableTest,
                         DefaultTestValuesForRunOptions, );
 

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -1087,7 +1087,79 @@ template class Templ <Arg>;
   EXPECT_FALSE(testStructuralMatch(t));
 }
 
-TEST_F(StructuralEquivalenceTemplateTest, DependentExprInTemplateArg) {
+TEST_F(StructuralEquivalenceTemplateTest, ConstantInTemplateArg) {
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
+      R"(
+      template <bool B>
+      struct X {};
+      X<true> Xx;
+      )",
+      R"(
+      template <bool B>
+      struct X {};
+      X<false> Xx;
+      )",
+      Lang_CXX11, classTemplateSpecializationDecl(hasName("X")));
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceTemplateTest, VariableInTemplateArg1) {
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
+      R"(
+      const int A = 1;
+      template <int I>
+      struct X {};
+      X<A> Xx;
+      )",
+      R"(
+      const int A = 2;
+      template <int I>
+      struct X {};
+      X<A> Xx;
+      )",
+      Lang_CXX11, classTemplateSpecializationDecl(hasName("X")));
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceTemplateTest, VariableInTemplateArg2) {
+  auto t = makeDecls<ClassTemplateSpecializationDecl>(
+      R"(
+      const int A = 1;
+      const int B = 2;
+      template <int I1, int I2>
+      struct X {};
+      X<A, B> Xx;
+      )",
+      R"(
+      const int A = 3;
+      const int B = 4;
+      template <int I1, int I2>
+      struct X {};
+      X<A, B> Xx;
+      )",
+      Lang_CXX11, classTemplateSpecializationDecl(hasName("X")));
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceTemplateTest, DependentExprInTemplateArg1) {
+  auto t = makeDecls<FriendDecl>(
+      R"(
+      template <bool B1>
+      struct X {
+        friend X<!B1>;
+      };
+      )",
+      R"(
+      template <bool B1>
+      struct X {
+        friend X<B1>;
+      };
+      )",
+      Lang_CXX11, friendDecl());
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceTemplateTest, DependentExprInTemplateArg2) {
   auto t = makeDecls<FriendDecl>(
       R"(
       template <bool B1, bool B2>

--- a/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/unittests/AST/StructuralEquivalenceTest.cpp
@@ -1087,6 +1087,24 @@ template class Templ <Arg>;
   EXPECT_FALSE(testStructuralMatch(t));
 }
 
+TEST_F(StructuralEquivalenceTemplateTest, DependentExprInTemplateArg) {
+  auto t = makeDecls<FriendDecl>(
+      R"(
+      template <bool B1, bool B2>
+      struct X {
+        friend X<!B1, B2>;
+      };
+      )",
+      R"(
+      template <bool B1, bool B2>
+      struct X {
+        friend X<B1, !B2>;
+      };
+      )",
+      Lang_CXX11, friendDecl());
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
 struct StructuralEquivalenceDependentTemplateArgsTest
     : StructuralEquivalenceTemplateTest {};
 


### PR DESCRIPTION
In the LLVM "Use.cpp" CTU analysis case this change makes all warnings (missing decl and "merged decl") disappear.