### PR TITLE
AnalyzerOption and BugReporterVisitor for the statistical checkers added

### DIFF
--- a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
+++ b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
@@ -381,5 +381,9 @@ ANALYZER_OPTION(
     "\"bfs_block_dfs_contents\".",
     "unexplored_first_queue")
 
+ANALYZER_OPTION(
+    StringRef, APIMetadataPath, "api-metadata-path",
+    "Directory where statistics are collected", "")
+
 #undef ANALYZER_OPTION_DEPENDS_ON_USER_MODE
 #undef ANALYZER_OPTION

--- a/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
+++ b/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
@@ -343,6 +343,23 @@ public:
                        BugReport &BR) override;
 };
 
+class SpecialReturnValueBRVisitor final : public BugReporterVisitor {
+
+  bool Satisfied;
+
+public:
+  SpecialReturnValueBRVisitor() : Satisfied(false) {}
+
+  void Profile(llvm::FoldingSetNodeID &ID) const override {
+    static int x = 0;
+    ID.AddPointer(&x);
+  }
+
+  std::shared_ptr<PathDiagnosticPiece> VisitNode(const ExplodedNode *Succ,
+                                                 BugReporterContext &BRC,
+                                                 BugReport &BR) override;
+};
+
 namespace bugreporter {
 
 /// Attempts to add visitors to track expression value back to its point of

--- a/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2613,6 +2613,7 @@ std::pair<BugReport*, std::unique_ptr<VisitorsDiagnosticsTy>> findValidReport(
     R->addVisitor(llvm::make_unique<NilReceiverBRVisitor>());
     R->addVisitor(llvm::make_unique<ConditionBRVisitor>());
     R->addVisitor(llvm::make_unique<CXXSelfAssignmentBRVisitor>());
+    R->addVisitor(llvm::make_unique<SpecialReturnValueBRVisitor>());
 
     BugReporterContext BRC(Reporter, ErrorGraph.BackMap);
 

--- a/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2504,3 +2504,48 @@ void FalsePositiveRefutationBRVisitor::Profile(
   static int Tag = 0;
   ID.AddPointer(&Tag);
 }
+
+std::shared_ptr<PathDiagnosticPiece>
+SpecialReturnValueBRVisitor::VisitNode(const ExplodedNode *Succ,
+                                       BugReporterContext &BRC, BugReport &BR) {
+  if (Satisfied)
+    return nullptr;
+
+  auto PS = Succ->getLocation().getAs<PostStmt>();
+  if (!PS.hasValue())
+    return nullptr;
+
+  auto Tag = PS->getTag();
+  if (!Tag)
+    return nullptr;
+
+  StringRef CheckerName, Msg;
+  std::tie(CheckerName, Msg) = Tag->getTagDescription().split(" : ");
+
+  if (CheckerName != "alpha.ericsson.statisticsbased.SpecialReturnValue")
+    return nullptr;
+
+  Satisfied = true;
+
+  assert(isa<CallExpr>(PS->getStmt()) &&
+         "Only CallExpr can \"return\" a value");
+  const auto *SpecCall = cast<CallExpr>(PS->getStmt());
+
+  const auto *LCtx = PS->getLocationContext();
+
+  auto L = PathDiagnosticLocation::createBegin(SpecCall, BRC.getSourceManager(),
+                                               LCtx);
+
+  if (!L.isValid() || !L.asLocation().isValid())
+    return nullptr;
+
+  SmallString<256> Buf;
+  llvm::raw_svector_ostream Out(Buf);
+
+  Out << "Assuming " << Msg << " (based on call statistics)";
+
+  auto Piece = std::make_shared<PathDiagnosticEventPiece>(L, Out.str());
+  Piece->addRange(SpecCall->getSourceRange());
+
+  return std::move(Piece);
+}

--- a/test/Analysis/analyzer-config.c
+++ b/test/Analysis/analyzer-config.c
@@ -3,6 +3,7 @@
 
 // CHECK: [config]
 // CHECK-NEXT: aggressive-binary-operation-simplification = false
+// CHECK-NEXT: api-metadata-path = ""
 // CHECK-NEXT: avoid-suppressing-null-argument-paths = false
 // CHECK-NEXT: c++-allocator-inlining = true
 // CHECK-NEXT: c++-container-inlining = false
@@ -53,4 +54,4 @@
 // CHECK-NEXT: unroll-loops = false
 // CHECK-NEXT: widen-loops = false
 // CHECK-NEXT: [stats]
-// CHECK-NEXT: num-entries = 50
+// CHECK-NEXT: num-entries = 51


### PR DESCRIPTION
Statistical checkers need an analyzer option (not checker option since it is a common option for multiple [all] statistical checkers) and a global bug reporter visitor that is added to every bug report. Neither can be done in the plugin.