### PR TITLE
Do not import FunctionTemplateDecl in record twice.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3102,6 +3102,9 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
         if (!D->doesThisDeclarationHaveABody()) {
           if (FunctionTemplateDecl *DescribedD =
                   D->getDescribedFunctionTemplate()) {
+            // Handle a "templated" function together with its described
+            // template. This avoids need for a similar check at import of the
+            // described template.
             assert(FoundByLookup->getDescribedFunctionTemplate() &&
                    "Templated function mapped to non-templated?");
             Importer.MapImported(DescribedD,

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2466,6 +2466,47 @@ TEST_P(ImportFunctionTemplates,
   EXPECT_TRUE(ImportedD);
 }
 
+TEST_P(ImportFunctionTemplates, ImportFunctionTemplateInRecordDeclTwice) {
+  auto Code =
+      R"(
+  class X {
+    template <class T>
+    void f(T t);
+  };
+  )";
+  Decl *FromTU1 = getTuDecl(Code, Lang_CXX, "input1.cc");
+  auto *FromD1 = FirstDeclMatcher<FunctionTemplateDecl>().match(
+      FromTU1, functionTemplateDecl(hasName("f")));
+  auto *ToD1 = Import(FromD1, Lang_CXX);
+  Decl *FromTU2 = getTuDecl(Code, Lang_CXX, "input2.cc");
+  auto *FromD2 = FirstDeclMatcher<FunctionTemplateDecl>().match(
+      FromTU2, functionTemplateDecl(hasName("f")));
+  auto *ToD2 = Import(FromD2, Lang_CXX);
+  EXPECT_EQ(ToD1, ToD2);
+}
+
+TEST_P(ImportFunctionTemplates,
+       ImportFunctionTemplateWithDefInRecordDeclTwice) {
+  auto Code =
+      R"(
+  class X {
+    template <class T>
+    void f(T t);
+  };
+  template <class T>
+  void X::f(T t) {};
+  )";
+  Decl *FromTU1 = getTuDecl(Code, Lang_CXX, "input1.cc");
+  auto *FromD1 = FirstDeclMatcher<FunctionTemplateDecl>().match(
+      FromTU1, functionTemplateDecl(hasName("f")));
+  auto *ToD1 = Import(FromD1, Lang_CXX);
+  Decl *FromTU2 = getTuDecl(Code, Lang_CXX, "input2.cc");
+  auto *FromD2 = FirstDeclMatcher<FunctionTemplateDecl>().match(
+      FromTU2, functionTemplateDecl(hasName("f")));
+  auto *ToD2 = Import(FromD2, Lang_CXX);
+  EXPECT_EQ(ToD1, ToD2);
+}
+
 struct ImportFriendFunctions : ImportFunctions {};
 
 TEST_P(ImportFriendFunctions, ImportFriendFunctionRedeclChainProto) {

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -2469,11 +2469,11 @@ TEST_P(ImportFunctionTemplates,
 TEST_P(ImportFunctionTemplates, ImportFunctionTemplateInRecordDeclTwice) {
   auto Code =
       R"(
-  class X {
-    template <class T>
-    void f(T t);
-  };
-  )";
+      class X {
+        template <class T>
+        void f(T t);
+      };
+      )";
   Decl *FromTU1 = getTuDecl(Code, Lang_CXX, "input1.cc");
   auto *FromD1 = FirstDeclMatcher<FunctionTemplateDecl>().match(
       FromTU1, functionTemplateDecl(hasName("f")));
@@ -2489,13 +2489,13 @@ TEST_P(ImportFunctionTemplates,
        ImportFunctionTemplateWithDefInRecordDeclTwice) {
   auto Code =
       R"(
-  class X {
-    template <class T>
-    void f(T t);
-  };
-  template <class T>
-  void X::f(T t) {};
-  )";
+      class X {
+        template <class T>
+        void f(T t);
+      };
+      template <class T>
+      void X::f(T t) {};
+      )";
   Decl *FromTU1 = getTuDecl(Code, Lang_CXX, "input1.cc");
   auto *FromD1 = FirstDeclMatcher<FunctionTemplateDecl>().match(
       FromTU1, functionTemplateDecl(hasName("f")));


### PR DESCRIPTION
For functions there is a check to not duplicate the declaration if it is in a record (class). For function templates there was no similar check, if a template (in the same class) was imported multiple times the `FunctionTemplateDecl` was created multiple times with the same templated `FunctionDecl`. This can result in problems with the declaration chain and assertions.