### PR TITLE
Fix a compiler warning.

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3097,11 +3097,11 @@ ExpectedDecl ASTNodeImporter::VisitFunctionDecl(FunctionDecl *D) {
   // overrides (even if they are part of the same redecl chain inside the
   // derived class.)
   if (FoundByLookup) {
-    if (auto *MD = dyn_cast<CXXMethodDecl>(FoundByLookup)) {
+    if (dyn_cast<CXXMethodDecl>(FoundByLookup)) {
       if (D->getLexicalDeclContext() == D->getDeclContext()) {
-        if (!D->doesThisDeclarationHaveABody())
+        if (!D->doesThisDeclarationHaveABody()) {
           return Importer.MapImported(D, FoundByLookup);
-        else {
+        } else {
           // Let's continue and build up the redecl chain in this case.
           // FIXME Merge the functions into one decl.
         }


### PR DESCRIPTION
Following warning is fixed:
```
[51/208] Building CXX object tools/clang/lib/AST/CMakeFiles/clangAST.dir/ASTImporter.cpp.o
llvm/tools/clang/lib/AST/ASTImporter.cpp: In member function ‘clang::ExpectedDecl clang::ASTNodeImporter::VisitFunctionDecl(clang::FunctionDecl*)’:
llvm/tools/clang/lib/AST/ASTImporter.cpp:3100:15: warning: unused variable ‘MD’ [-Wunused-variable]
     if (auto *MD = dyn_cast<CXXMethodDecl>(FoundByLookup)) {
               ^
```
(Additional code format change is made.)