### PR TITLE
HandleNameConflict should receive the SearchName as parameter

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2524,7 +2524,8 @@ ExpectedDecl ASTNodeImporter::VisitEnumDecl(EnumDecl *D) {
 
     if (!ConflictingDecls.empty()) {
       Expected<DeclarationName> Resolution = Importer.HandleNameConflict(
-          Name, DC, IDNS, ConflictingDecls.data(), ConflictingDecls.size());
+          SearchName, DC, IDNS, ConflictingDecls.data(),
+          ConflictingDecls.size());
       if (Resolution)
         Name = Resolution.get();
       else
@@ -2661,7 +2662,8 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
 
     if (!ConflictingDecls.empty() && SearchName) {
       Expected<DeclarationName> Resolution = Importer.HandleNameConflict(
-          Name, DC, IDNS, ConflictingDecls.data(), ConflictingDecls.size());
+          SearchName, DC, IDNS, ConflictingDecls.data(),
+          ConflictingDecls.size());
       if (Resolution)
         Name = Resolution.get();
       else


### PR DESCRIPTION
There has been a discussion about the name conflicts of typedef-ed enums and records. HandleNameConflict should receive the SearchName, but the resolution of the conflict should update the original Name string.