### PR TITLE
Handle CTU diagnostic macro expansions better.

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -35,6 +35,7 @@ namespace clang {
 
 class ASTContext;
 class ASTImporterSharedState;
+class ASTUnit;
 class Attr;
 class CXXBaseSpecifier;
 class CXXCtorInitializer;
@@ -132,6 +133,9 @@ class TypeSourceInfo;
     /// The file managers we're importing to and from.
     FileManager &ToFileManager, &FromFileManager;
 
+    /// The ASTUnit that this importer belongs to, if any.
+    ASTUnit *Unit;
+
     /// Whether to perform a minimal import.
     bool Minimal;
 
@@ -166,10 +170,6 @@ class TypeSourceInfo;
     /// manager to the corresponding FileIDs in the "to" source manager.
     llvm::DenseMap<FileID, FileID> ImportedFileIDs;
 
-    /// Mapping from the already-imported FileIDs in the "to" source
-    /// manager to the corresponding FileIDs in the "from" source manager.
-    llvm::DenseMap<FileID, FileID> ImportedFromFileIDs;
-
     /// Mapping from the already-imported CXXBasesSpecifier in
     ///  the "from" source manager to the corresponding CXXBasesSpecifier
     ///  in the "to" source manager.
@@ -187,7 +187,6 @@ class TypeSourceInfo;
     virtual Expected<Decl *> ImportImpl(Decl *From);
 
   public:
-
     /// \param ToContext The context we'll be importing into.
     ///
     /// \param ToFileManager The file manager we'll be importing into.
@@ -200,13 +199,19 @@ class TypeSourceInfo;
     /// as little as it can, e.g., by importing declarations as forward
     /// declarations that can be completed at a later point.
     ///
-    /// \param LookupTable The importer specific lookup table which may be
-    /// shared amongst several ASTImporter objects.
-    /// If not set then the original C/C++ lookup is used.
+    /// \param SharedState The shared importer state which may be
+    /// shared amongst several ASTImporter objects. It is used to importer
+    /// specific lookup of declarations.
+    /// If this is not set then the original C/C++ lookup is used.
+    ///
+    /// \param Unit Pointer to an ASTUnit that contains this importer, if any.
+    /// A mapping of imported FileID's to ASTUnit is stored in the shared state,
+    /// if both are set.
     ASTImporter(ASTContext &ToContext, FileManager &ToFileManager,
                 ASTContext &FromContext, FileManager &FromFileManager,
                 bool MinimalImport,
-                std::shared_ptr<ASTImporterSharedState> SharedState = nullptr);
+                std::shared_ptr<ASTImporterSharedState> SharedState = nullptr,
+                ASTUnit *Unit = nullptr);
 
     virtual ~ASTImporter();
 
@@ -312,10 +317,6 @@ class TypeSourceInfo;
     /// \returns The equivalent source location in the "to" context, or the
     /// import error.
     llvm::Expected<SourceLocation> Import(SourceLocation FromLoc);
-
-    /// Determine the original FileID (in the "from" source manager) for an
-    /// imported FileID (in the "to" source manager).
-    llvm::Optional<FileID> GetFromFileID(FileID ToID) const;
 
     /// Import the given source range from the "from" context into
     /// the "to" context.

--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -166,6 +166,10 @@ class TypeSourceInfo;
     /// manager to the corresponding FileIDs in the "to" source manager.
     llvm::DenseMap<FileID, FileID> ImportedFileIDs;
 
+    /// Mapping from the already-imported FileIDs in the "to" source
+    /// manager to the corresponding FileIDs in the "from" source manager.
+    llvm::DenseMap<FileID, FileID> ImportedFromFileIDs;
+
     /// Mapping from the already-imported CXXBasesSpecifier in
     ///  the "from" source manager to the corresponding CXXBasesSpecifier
     ///  in the "to" source manager.
@@ -308,6 +312,10 @@ class TypeSourceInfo;
     /// \returns The equivalent source location in the "to" context, or the
     /// import error.
     llvm::Expected<SourceLocation> Import(SourceLocation FromLoc);
+
+    /// Determine the original FileID (in the "from" source manager) for an
+    /// imported FileID (in the "to" source manager).
+    llvm::Optional<FileID> GetFromFileID(FileID ToID) const;
 
     /// Import the given source range from the "from" context into
     /// the "to" context.

--- a/include/clang/AST/ASTImporterSharedState.h
+++ b/include/clang/AST/ASTImporterSharedState.h
@@ -47,7 +47,12 @@ private:
 
   /// Map of imported FileID's (in "To" context) to FileID in "From" context
   /// and the ASTUnit that contains the preprocessor and source manager for the
-  /// "From" FileID.
+  /// "From" FileID. This map is used to lookup a FileID and its SourceManager
+  /// when knowing only the FileID in the 'To' context. The FileID could be
+  /// imported by any of multiple ASTImporter objects. The map is used because
+  /// we do not want to loop over all ASTImporter's to find the one that
+  /// imported the FileID. (The ASTUnit is usable to get the SourceManager and
+  /// additional data.)
   ImportedFileIDMap ImportedFileIDs;
 
   // FIXME put ImportedFromDecls here!

--- a/include/clang/AST/ASTImporterSharedState.h
+++ b/include/clang/AST/ASTImporterSharedState.h
@@ -16,18 +16,24 @@
 #define LLVM_CLANG_AST_ASTIMPORTERSHAREDSTATE_H
 
 #include "clang/AST/ASTImporterLookupTable.h"
+#include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/DenseMap.h"
 // FIXME We need this because of ImportError.
 #include "clang/AST/ASTImporter.h"
 
 namespace clang {
 
+class ASTUnit;
 class TranslationUnitDecl;
 
 /// Importer specific state, which may be shared amongst several ASTImporter
 /// objects.
 class ASTImporterSharedState {
+public:
+  using ImportedFileIDMap =
+      llvm::DenseMap<FileID, std::pair<FileID, ASTUnit *>>;
 
+private:
   /// Pointer to the import specific lookup table.
   std::unique_ptr<ASTImporterLookupTable> LookupTable;
 
@@ -38,6 +44,11 @@ class ASTImporterSharedState {
   /// ImportedFromDecls. This map is updated continuously during imports and
   /// never cleared (like ImportedFromDecls).
   llvm::DenseMap<Decl *, ImportError> ImportErrors;
+
+  /// Map of imported FileID's (in "To" context) to FileID in "From" context
+  /// and the ASTUnit that contains the preprocessor and source manager for the
+  /// "From" FileID.
+  ImportedFileIDMap ImportedFileIDs;
 
   // FIXME put ImportedFromDecls here!
   // And from that point we can better encapsulate the lookup table.
@@ -61,6 +72,12 @@ public:
 
   void setImportDeclError(Decl *To, ImportError Error) {
     ImportErrors[To] = Error;
+  }
+
+  ImportedFileIDMap &getImportedFileIDs() { return ImportedFileIDs; }
+
+  const ImportedFileIDMap &getImportedFileIDs() const {
+    return ImportedFileIDs;
   }
 };
 

--- a/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/include/clang/CrossTU/CrossTranslationUnit.h
@@ -160,6 +160,16 @@ public:
   /// Emit diagnostics for the user for potential configuration errors.
   void emitCrossTUDiagnostics(const IndexError &IE);
 
+  /// Determine the original source location in the original TU for an
+  /// imported source location.
+  /// \p ToLoc Source location in the imported-to AST.
+  /// \p FromLoc Returned source location in the imported-from AST.
+  /// \return The ASTUnit for the source file of FromLoc. If the ToLoc is not an
+  /// imported location or other error occurs, nullptr is returned.
+  clang::ASTUnit *
+  GetImportedFromSourceLocation(const clang::SourceLocation &ToLoc,
+                                clang::SourceLocation &FromLoc) const;
+
 private:
   void lazyInitImporterSharedSt(TranslationUnitDecl *ToTU);
   ASTImporter &getOrCreateASTImporter(ASTContext &From);
@@ -168,6 +178,7 @@ private:
 
   llvm::StringMap<std::unique_ptr<clang::ASTUnit>> FileASTUnitMap;
   llvm::StringMap<clang::ASTUnit *> FunctionASTUnitMap;
+  llvm::StringMap<clang::ASTUnit *> SrcFileASTUnitMap;
   llvm::StringMap<std::string> FunctionFileMap;
   llvm::DenseMap<TranslationUnitDecl *, std::unique_ptr<ASTImporter>>
       ASTUnitImporterMap;

--- a/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/include/clang/CrossTU/CrossTranslationUnit.h
@@ -173,7 +173,7 @@ public:
 
 private:
   void lazyInitImporterSharedSt(TranslationUnitDecl *ToTU);
-  ASTImporter &getOrCreateASTImporter(ASTContext &From, ASTUnit *Unit);
+  ASTImporter &getOrCreateASTImporter(ASTUnit *Unit);
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,
                                                 StringRef LookupFnName);
 

--- a/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/include/clang/CrossTU/CrossTranslationUnit.h
@@ -152,7 +152,8 @@ public:
   ///        was passed to the constructor.
   ///
   /// \return Returns the resulting definition or an error.
-  llvm::Expected<const FunctionDecl *> importDefinition(const FunctionDecl *FD);
+  llvm::Expected<const FunctionDecl *> importDefinition(const FunctionDecl *FD,
+                                                        ASTUnit *Unit);
 
   /// Get a name to identify a function.
   static std::string getLookupName(const NamedDecl *ND);
@@ -163,16 +164,16 @@ public:
   /// Determine the original source location in the original TU for an
   /// imported source location.
   /// \p ToLoc Source location in the imported-to AST.
-  /// \p FromLoc Returned source location in the imported-from AST.
-  /// \return The ASTUnit for the source file of FromLoc. If the ToLoc is not an
-  /// imported location or other error occurs, nullptr is returned.
-  clang::ASTUnit *
-  GetImportedFromSourceLocation(const clang::SourceLocation &ToLoc,
-                                clang::SourceLocation &FromLoc) const;
+  /// \return Source location in the imported-from AST and the corresponding
+  /// ASTUnit.
+  /// If any error happens (ToLoc is a non-imported source location) empty is
+  /// returned.
+  llvm::Optional<std::pair<SourceLocation /*FromLoc*/, ASTUnit *>>
+  GetImportedFromSourceLocation(const clang::SourceLocation &ToLoc) const;
 
 private:
   void lazyInitImporterSharedSt(TranslationUnitDecl *ToTU);
-  ASTImporter &getOrCreateASTImporter(ASTContext &From);
+  ASTImporter &getOrCreateASTImporter(ASTContext &From, ASTUnit *Unit);
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,
                                                 StringRef LookupFnName);
 
@@ -180,8 +181,6 @@ private:
   llvm::StringMap<std::unique_ptr<clang::ASTUnit>> FileASTUnitMap;
   /// Map from a function lookup name (USR) to the ASTUnit for that function.
   llvm::StringMap<clang::ASTUnit *> FunctionASTUnitMap;
-  /// Map from the full source file name to the ASTUnit for that source file.
-  llvm::StringMap<clang::ASTUnit *> SrcFileASTUnitMap;
   /// Map from function lookup name to the AST file name.
   // This is the content of the "index file".
   llvm::StringMap<std::string> FunctionFileMap;

--- a/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/include/clang/CrossTU/CrossTranslationUnit.h
@@ -176,9 +176,14 @@ private:
   const FunctionDecl *findFunctionInDeclContext(const DeclContext *DC,
                                                 StringRef LookupFnName);
 
+  /// Map from the full name of the AST file to the belonging ASTUnit structure.
   llvm::StringMap<std::unique_ptr<clang::ASTUnit>> FileASTUnitMap;
+  /// Map from a function lookup name (USR) to the ASTUnit for that function.
   llvm::StringMap<clang::ASTUnit *> FunctionASTUnitMap;
+  /// Map from the full source file name to the ASTUnit for that source file.
   llvm::StringMap<clang::ASTUnit *> SrcFileASTUnitMap;
+  /// Map from function lookup name to the AST file name.
+  // This is the content of the "index file".
   llvm::StringMap<std::string> FunctionFileMap;
   llvm::DenseMap<TranslationUnitDecl *, std::unique_ptr<ASTImporter>>
       ASTUnitImporterMap;

--- a/include/clang/StaticAnalyzer/Core/PathDiagnosticConsumers.h
+++ b/include/clang/StaticAnalyzer/Core/PathDiagnosticConsumers.h
@@ -21,17 +21,19 @@ namespace clang {
 
 class AnalyzerOptions;
 class Preprocessor;
+namespace cross_tu {
+class CrossTranslationUnitContext;
+}
 
 namespace ento {
 
 class PathDiagnosticConsumer;
 typedef std::vector<PathDiagnosticConsumer*> PathDiagnosticConsumers;
 
-#define ANALYSIS_DIAGNOSTICS(NAME, CMDFLAG, DESC, CREATEFN)\
-void CREATEFN(AnalyzerOptions &AnalyzerOpts,\
-              PathDiagnosticConsumers &C,\
-              const std::string &Prefix,\
-              const Preprocessor &PP);
+#define ANALYSIS_DIAGNOSTICS(NAME, CMDFLAG, DESC, CREATEFN)                    \
+  void CREATEFN(AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,     \
+                const std::string &Prefix, const Preprocessor &PP,             \
+                const cross_tu::CrossTranslationUnitContext &CTU);
 #include "clang/StaticAnalyzer/Core/Analyses.def"
 
 } // end 'ento' namespace

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8872,7 +8872,16 @@ Expected<FileID> ASTImporter::Import(FileID FromID, bool IsBuiltin) {
   assert(ToID.isValid() && "Unexpected invalid fileID was created.");
 
   ImportedFileIDs[FromID] = ToID;
+  ImportedFromFileIDs[ToID] = FromID;
   return ToID;
+}
+
+llvm::Optional<FileID> ASTImporter::GetFromFileID(FileID ToID) const {
+  llvm::DenseMap<FileID, FileID>::const_iterator Pos =
+      ImportedFromFileIDs.find(ToID);
+  if (Pos != ImportedFromFileIDs.end())
+    return Pos->second;
+  return {};
 }
 
 Expected<CXXCtorInitializer *> ASTImporter::Import(CXXCtorInitializer *From) {

--- a/lib/Basic/SourceManager.cpp
+++ b/lib/Basic/SourceManager.cpp
@@ -2037,9 +2037,7 @@ bool SourceManager::isBeforeInTranslationUnit(SourceLocation LHS,
     return LOffs.second < ROffs.second;
   }
 
-  // If SourceLocations originate from different TUs, but cannot be handled
-  // by one of the previous cases, just compare the FileIDs directly.
-  return LOffs.first < ROffs.first;
+  llvm_unreachable("Unsortable locations found");
 }
 
 std::pair<bool, bool> SourceManager::isInTheSameTranslationUnit(

--- a/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/lib/CrossTU/CrossTranslationUnit.cpp
@@ -349,7 +349,12 @@ llvm::Expected<ASTUnit *> CrossTranslationUnitContext::loadExternalAST(
           ASTUnit::LoadEverything, Diags, CI.getFileSystemOpts()));
       Unit = LoadedUnit.get();
       FileASTUnitMap[ASTFileName] = std::move(LoadedUnit);
-      SrcFileASTUnitMap[Unit->getOriginalSourceFileName()] = Unit;
+      {
+        ASTUnit *&UnitEntry =
+            SrcFileASTUnitMap[Unit->getOriginalSourceFileName()];
+        assert(!UnitEntry && "Duplicate source file names encountered!");
+        UnitEntry = Unit;
+      }
       ++NumASTLoaded;
       if (DisplayCTUProgress) {
         llvm::errs() << "CTU loaded AST file: "

--- a/lib/StaticAnalyzer/Core/HTMLDiagnostics.cpp
+++ b/lib/StaticAnalyzer/Core/HTMLDiagnostics.cpp
@@ -134,17 +134,17 @@ private:
 
 } // namespace
 
-void ento::createHTMLDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                        PathDiagnosticConsumers &C,
-                                        const std::string& prefix,
-                                        const Preprocessor &PP) {
+void ento::createHTMLDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &prefix, const Preprocessor &PP,
+    const cross_tu::CrossTranslationUnitContext &) {
   C.push_back(new HTMLDiagnostics(AnalyzerOpts, prefix, PP, true));
 }
 
-void ento::createHTMLSingleFileDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                                  PathDiagnosticConsumers &C,
-                                                  const std::string& prefix,
-                                                  const Preprocessor &PP) {
+void ento::createHTMLSingleFileDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &prefix, const Preprocessor &PP,
+    const cross_tu::CrossTranslationUnitContext &) {
   C.push_back(new HTMLDiagnostics(AnalyzerOpts, prefix, PP, false));
 }
 

--- a/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
+++ b/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
@@ -15,6 +15,8 @@
 #include "clang/Basic/PlistSupport.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Version.h"
+#include "clang/CrossTU/CrossTranslationUnit.h"
+#include "clang/Frontend/ASTUnit.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/TokenConcatenation.h"
 #include "clang/Rewrite/Core/HTMLRewrite.h"
@@ -22,9 +24,9 @@
 #include "clang/StaticAnalyzer/Core/BugReporter/PathDiagnostic.h"
 #include "clang/StaticAnalyzer/Core/IssueHash.h"
 #include "clang/StaticAnalyzer/Core/PathDiagnosticConsumers.h"
-#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Casting.h"
 
 using namespace clang;
@@ -40,12 +42,13 @@ namespace {
   class PlistDiagnostics : public PathDiagnosticConsumer {
     const std::string OutputFile;
     const Preprocessor &PP;
+    const cross_tu::CrossTranslationUnitContext &CTU;
     AnalyzerOptions &AnOpts;
     const bool SupportsCrossFileDiagnostics;
   public:
-    PlistDiagnostics(AnalyzerOptions &AnalyzerOpts,
-                     const std::string& prefix,
+    PlistDiagnostics(AnalyzerOptions &AnalyzerOpts, const std::string &prefix,
                      const Preprocessor &PP,
+                     const cross_tu::CrossTranslationUnitContext &CTU,
                      bool supportsMultipleFiles);
 
     ~PlistDiagnostics() override {}
@@ -74,13 +77,14 @@ class PlistPrinter {
   const FIDMap& FM;
   AnalyzerOptions &AnOpts;
   const Preprocessor &PP;
+  const cross_tu::CrossTranslationUnitContext &CTU;
   llvm::SmallVector<const PathDiagnosticMacroPiece *, 0> MacroPieces;
 
 public:
-  PlistPrinter(const FIDMap& FM, AnalyzerOptions &AnOpts,
-               const Preprocessor &PP)
-    : FM(FM), AnOpts(AnOpts), PP(PP) {
-  }
+  PlistPrinter(const FIDMap &FM, AnalyzerOptions &AnOpts,
+               const Preprocessor &PP,
+               const cross_tu::CrossTranslationUnitContext &CTU)
+      : FM(FM), AnOpts(AnOpts), PP(PP), CTU(CTU) {}
 
   void ReportDiag(raw_ostream &o, const PathDiagnosticPiece& P) {
     ReportPiece(o, P, /*indent*/ 4, /*depth*/ 0, /*includeControlFlow*/ true);
@@ -154,9 +158,9 @@ struct ExpansionInfo {
 
 } // end of anonymous namespace
 
-static void printBugPath(llvm::raw_ostream &o, const FIDMap& FM,
-                         AnalyzerOptions &AnOpts,
-                         const Preprocessor &PP,
+static void printBugPath(llvm::raw_ostream &o, const FIDMap &FM,
+                         AnalyzerOptions &AnOpts, const Preprocessor &PP,
+                         const cross_tu::CrossTranslationUnitContext &CTU,
                          const PathPieces &Path);
 
 /// Print coverage information to output stream {@code o}.
@@ -167,8 +171,9 @@ static void printCoverage(const PathDiagnostic *D,
                           FIDMap &FM,
                           llvm::raw_fd_ostream &o);
 
-static ExpansionInfo getExpandedMacro(SourceLocation MacroLoc,
-                                      const Preprocessor &PP);
+static ExpansionInfo
+getExpandedMacro(SourceLocation MacroLoc, const Preprocessor &PP,
+                 const cross_tu::CrossTranslationUnitContext &CTU);
 
 //===----------------------------------------------------------------------===//
 // Methods of PlistPrinter.
@@ -342,7 +347,7 @@ void PlistPrinter::ReportMacroExpansions(raw_ostream &o, unsigned indent) {
 
   for (const PathDiagnosticMacroPiece *P : MacroPieces) {
     const SourceManager &SM = PP.getSourceManager();
-    ExpansionInfo EI = getExpandedMacro(P->getLocation().asLocation(), PP);
+    ExpansionInfo EI = getExpandedMacro(P->getLocation().asLocation(), PP, CTU);
 
     Indent(o, indent) << "<dict>\n";
     ++indent;
@@ -435,11 +440,11 @@ static void printCoverage(const PathDiagnostic *D,
   assert(IndentLevel == InputIndentLevel);
 }
 
-static void printBugPath(llvm::raw_ostream &o, const FIDMap& FM,
-                         AnalyzerOptions &AnOpts,
-                         const Preprocessor &PP,
+static void printBugPath(llvm::raw_ostream &o, const FIDMap &FM,
+                         AnalyzerOptions &AnOpts, const Preprocessor &PP,
+                         const cross_tu::CrossTranslationUnitContext &CTU,
                          const PathPieces &Path) {
-  PlistPrinter Printer(FM, AnOpts, PP);
+  PlistPrinter Printer(FM, AnOpts, PP, CTU);
   assert(std::is_partitioned(
            Path.begin(), Path.end(),
            [](const std::shared_ptr<PathDiagnosticPiece> &E)
@@ -485,26 +490,26 @@ static void printBugPath(llvm::raw_ostream &o, const FIDMap& FM,
 // Methods of PlistDiagnostics.
 //===----------------------------------------------------------------------===//
 
-PlistDiagnostics::PlistDiagnostics(AnalyzerOptions &AnalyzerOpts,
-                                   const std::string& output,
-                                   const Preprocessor &PP,
-                                   bool supportsMultipleFiles)
-  : OutputFile(output), PP(PP), AnOpts(AnalyzerOpts),
-    SupportsCrossFileDiagnostics(supportsMultipleFiles) {}
+PlistDiagnostics::PlistDiagnostics(
+    AnalyzerOptions &AnalyzerOpts, const std::string &output,
+    const Preprocessor &PP, const cross_tu::CrossTranslationUnitContext &CTU,
+    bool supportsMultipleFiles)
+    : OutputFile(output), PP(PP), CTU(CTU), AnOpts(AnalyzerOpts),
+      SupportsCrossFileDiagnostics(supportsMultipleFiles) {}
 
-void ento::createPlistDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                         PathDiagnosticConsumers &C,
-                                         const std::string& s,
-                                         const Preprocessor &PP) {
-  C.push_back(new PlistDiagnostics(AnalyzerOpts, s, PP,
+void ento::createPlistDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &s, const Preprocessor &PP,
+    const cross_tu::CrossTranslationUnitContext &CTU) {
+  C.push_back(new PlistDiagnostics(AnalyzerOpts, s, PP, CTU,
                                    /*supportsMultipleFiles*/ false));
 }
 
-void ento::createPlistMultiFileDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                                  PathDiagnosticConsumers &C,
-                                                  const std::string &s,
-                                                  const Preprocessor &PP) {
-  C.push_back(new PlistDiagnostics(AnalyzerOpts, s, PP,
+void ento::createPlistMultiFileDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &s, const Preprocessor &PP,
+    const cross_tu::CrossTranslationUnitContext &CTU) {
+  C.push_back(new PlistDiagnostics(AnalyzerOpts, s, PP, CTU,
                                    /*supportsMultipleFiles*/ true));
 }
 void PlistDiagnostics::FlushDiagnosticsImpl(
@@ -581,7 +586,7 @@ void PlistDiagnostics::FlushDiagnosticsImpl(
     o << "  <dict>\n";
 
     const PathDiagnostic *D = *DI;
-    printBugPath(o, FM, AnOpts, PP, D->path);
+    printBugPath(o, FM, AnOpts, PP, CTU, D->path);
 
     // Output the bug type and bug category.
     o << "   <key>description</key>";
@@ -834,17 +839,25 @@ static const MacroInfo *getMacroInfoForLocation(const Preprocessor &PP,
 // Definitions of helper functions and methods for expanding macros.
 //===----------------------------------------------------------------------===//
 
-static ExpansionInfo getExpandedMacro(SourceLocation MacroLoc,
-                                      const Preprocessor &PP) {
+static ExpansionInfo
+getExpandedMacro(SourceLocation MacroLoc, const Preprocessor &PP,
+                 const cross_tu::CrossTranslationUnitContext &CTU) {
+
+  SourceLocation MacroOriginalLoc;
+  const Preprocessor *PPToUse = &PP;
+  if (clang::ASTUnit *Unit =
+          CTU.GetImportedFromSourceLocation(MacroLoc, MacroOriginalLoc)) {
+    PPToUse = &Unit->getPreprocessor();
+    MacroLoc = MacroOriginalLoc;
+  }
 
   llvm::SmallString<200> ExpansionBuf;
   llvm::raw_svector_ostream OS(ExpansionBuf);
-  TokenPrinter Printer(OS, PP);
+  TokenPrinter Printer(OS, *PPToUse);
   llvm::SmallPtrSet<IdentifierInfo*, 8> AlreadyProcessedTokens;
 
-  std::string MacroName =
-            getMacroNameAndPrintExpansion(Printer, MacroLoc, PP, MacroArgMap{},
-                                         AlreadyProcessedTokens);
+  std::string MacroName = getMacroNameAndPrintExpansion(
+      Printer, MacroLoc, *PPToUse, MacroArgMap{}, AlreadyProcessedTokens);
   return { MacroName, OS.str() };
 }
 

--- a/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
+++ b/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
@@ -843,12 +843,10 @@ static ExpansionInfo
 getExpandedMacro(SourceLocation MacroLoc, const Preprocessor &PP,
                  const cross_tu::CrossTranslationUnitContext &CTU) {
 
-  SourceLocation MacroOriginalLoc;
   const Preprocessor *PPToUse = &PP;
-  if (clang::ASTUnit *Unit =
-          CTU.GetImportedFromSourceLocation(MacroLoc, MacroOriginalLoc)) {
-    PPToUse = &Unit->getPreprocessor();
-    MacroLoc = MacroOriginalLoc;
+  if (auto LocAndUnit = CTU.GetImportedFromSourceLocation(MacroLoc)) {
+    MacroLoc = LocAndUnit->first;
+    PPToUse = &LocAndUnit->second->getPreprocessor();
   }
 
   llvm::SmallString<200> ExpansionBuf;

--- a/lib/StaticAnalyzer/Core/SarifDiagnostics.cpp
+++ b/lib/StaticAnalyzer/Core/SarifDiagnostics.cpp
@@ -44,10 +44,10 @@ public:
 };
 } // end anonymous namespace
 
-void ento::createSarifDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                         PathDiagnosticConsumers &C,
-                                         const std::string &Output,
-                                         const Preprocessor &) {
+void ento::createSarifDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &Output, const Preprocessor &,
+    const cross_tu::CrossTranslationUnitContext &) {
   C.push_back(new SarifDiagnostics(AnalyzerOpts, Output));
 }
 

--- a/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -65,19 +65,19 @@ STATISTIC(MaxCFGSize, "The maximum number of basic blocks in a function.");
 // Special PathDiagnosticConsumers.
 //===----------------------------------------------------------------------===//
 
-void ento::createPlistHTMLDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                             PathDiagnosticConsumers &C,
-                                             const std::string &prefix,
-                                             const Preprocessor &PP) {
+void ento::createPlistHTMLDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &prefix, const Preprocessor &PP,
+    const cross_tu::CrossTranslationUnitContext &CTU) {
   createHTMLDiagnosticConsumer(AnalyzerOpts, C,
-                               llvm::sys::path::parent_path(prefix), PP);
-  createPlistMultiFileDiagnosticConsumer(AnalyzerOpts, C, prefix, PP);
+                               llvm::sys::path::parent_path(prefix), PP, CTU);
+  createPlistMultiFileDiagnosticConsumer(AnalyzerOpts, C, prefix, PP, CTU);
 }
 
-void ento::createTextPathDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
-                                            PathDiagnosticConsumers &C,
-                                            const std::string &Prefix,
-                                            const clang::Preprocessor &PP) {
+void ento::createTextPathDiagnosticConsumer(
+    AnalyzerOptions &AnalyzerOpts, PathDiagnosticConsumers &C,
+    const std::string &Prefix, const clang::Preprocessor &PP,
+    const cross_tu::CrossTranslationUnitContext &CTU) {
   llvm_unreachable("'text' consumer should be enabled on ClangDiags");
 }
 
@@ -234,7 +234,7 @@ public:
         default:
 #define ANALYSIS_DIAGNOSTICS(NAME, CMDFLAG, DESC, CREATEFN)                    \
   case PD_##NAME:                                                              \
-    CREATEFN(*Opts.get(), PathConsumers, OutDir, PP);                       \
+    CREATEFN(*Opts.get(), PathConsumers, OutDir, PP, CTU);                     \
     break;
 #include "clang/StaticAnalyzer/Core/Analyses.def"
         }

--- a/test/Analysis/Inputs/plist-macros-ctu.c
+++ b/test/Analysis/Inputs/plist-macros-ctu.c
@@ -1,4 +1,6 @@
 
+#include "plist-macros-ctu.h"
+
 #define M *X = (int *)0
 
 void F1(int **X) {

--- a/test/Analysis/Inputs/plist-macros-ctu.c
+++ b/test/Analysis/Inputs/plist-macros-ctu.c
@@ -11,3 +11,9 @@ void F1(int **X) {
 void F2(int **Y) {
   M;
 }
+
+#define M1 *Z = (int *)0
+
+void F3(int **Z) {
+  M1;
+}

--- a/test/Analysis/Inputs/plist-macros-ctu.c
+++ b/test/Analysis/Inputs/plist-macros-ctu.c
@@ -1,0 +1,13 @@
+
+#define M *X = (int *)0
+
+void F1(int **X) {
+  M;
+}
+
+#undef M
+#define M *Y = (int *)0
+
+void F2(int **Y) {
+  M;
+}

--- a/test/Analysis/Inputs/plist-macros-ctu.h
+++ b/test/Analysis/Inputs/plist-macros-ctu.h
@@ -1,0 +1,4 @@
+#define M_H *A = (int *)0
+void F_H(int **A) {
+  M_H;
+}

--- a/test/Analysis/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt
+++ b/test/Analysis/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt
@@ -1,0 +1,2 @@
+c:@F@F1 plist-macros-ctu.c.ast
+c:@F@F2 plist-macros-ctu.c.ast

--- a/test/Analysis/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt
+++ b/test/Analysis/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt
@@ -1,3 +1,4 @@
 c:@F@F1 plist-macros-ctu.c.ast
 c:@F@F2 plist-macros-ctu.c.ast
 c:@F@F3 plist-macros-ctu.c.ast
+c:@F@F_H plist-macros-ctu.c.ast

--- a/test/Analysis/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt
+++ b/test/Analysis/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt
@@ -1,2 +1,3 @@
 c:@F@F1 plist-macros-ctu.c.ast
 c:@F@F2 plist-macros-ctu.c.ast
+c:@F@F3 plist-macros-ctu.c.ast

--- a/test/Analysis/plist-macros-with-expansion-ctu.c
+++ b/test/Analysis/plist-macros-with-expansion-ctu.c
@@ -17,6 +17,7 @@
 extern void F1(int **);
 extern void F2(int **);
 extern void F3(int **);
+extern void F_H(int **);
 
 void test0() {
   int *X;
@@ -68,3 +69,12 @@ void test4() {
 // CHECK-NEXT: <key>expansion</key><string>F2(&amp;X)</string>
 // CHECK: <key>name</key><string>M</string>
 // CHECK-NEXT: <key>expansion</key><string>*Y = (int *)0</string>
+
+void test_h() {
+  int *X;
+  F_H(&X);
+  *X = 1; // expected-warning{{Dereference of null pointer}}
+}
+
+// CHECK: <key>name</key><string>M_H</string>
+// CHECK-NEXT: <key>expansion</key><string>*A = (int *)0</string>

--- a/test/Analysis/plist-macros-with-expansion-ctu.c
+++ b/test/Analysis/plist-macros-with-expansion-ctu.c
@@ -16,6 +16,16 @@
 
 extern void F1(int **);
 extern void F2(int **);
+extern void F3(int **);
+
+void test0() {
+  int *X;
+  F3(&X);
+  *X = 1; // expected-warning{{Dereference of null pointer}}
+}
+// CHECK: <key>name</key><string>M1</string>
+// CHECK-NEXT: <key>expansion</key><string>*Z = (int *)0</string>
+
 
 void test1() {
   int *X;

--- a/test/Analysis/plist-macros-with-expansion-ctu.c
+++ b/test/Analysis/plist-macros-with-expansion-ctu.c
@@ -1,0 +1,60 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: mkdir -p %t/ctudir
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu \
+// RUN:   -emit-pch -o %t/ctudir/plist-macros-ctu.c.ast %S/Inputs/plist-macros-ctu.c
+// RUN: cp %S/Inputs/plist-macros-with-expansion-ctu.c.externalDefMap.txt %t/ctudir/externalDefMap.txt
+
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
+// RUN:   -analyzer-config ctu-dir=%t/ctudir \
+// RUN:   -analyzer-config expand-macros=true \
+// RUN:   -analyzer-output=plist-multi-file -o %t.plist -verify %s
+
+// Check the macro expansions from the plist output here, to make the test more
+// understandable.
+//   RUN: FileCheck --input-file=%t.plist %s
+
+extern void F1(int **);
+extern void F2(int **);
+
+void test1() {
+  int *X;
+  F1(&X);
+  *X = 1; // expected-warning{{Dereference of null pointer}}
+}
+// CHECK: <key>name</key><string>M</string>
+// CHECK-NEXT: <key>expansion</key><string>*X = (int *)0</string>
+
+void test2() {
+  int *X;
+  F2(&X);
+  *X = 1; // expected-warning{{Dereference of null pointer}}
+}
+// CHECK: <key>name</key><string>M</string>
+// CHECK-NEXT: <key>expansion</key><string>*Y = (int *)0</string>
+
+#define M F1(&X)
+
+void test3() {
+  int *X;
+  M;
+  *X = 1; // expected-warning{{Dereference of null pointer}}
+}
+// CHECK: <key>name</key><string>M</string>
+// CHECK-NEXT: <key>expansion</key><string>F1(&amp;X)</string>
+// CHECK: <key>name</key><string>M</string>
+// CHECK-NEXT: <key>expansion</key><string>*X = (int *)0</string>
+
+#undef M
+#define M F2(&X)
+
+void test4() {
+  int *X;
+  M;
+  *X = 1; // expected-warning{{Dereference of null pointer}}
+}
+
+// CHECK: <key>name</key><string>M</string>
+// CHECK-NEXT: <key>expansion</key><string>F2(&amp;X)</string>
+// CHECK: <key>name</key><string>M</string>
+// CHECK-NEXT: <key>expansion</key><string>*Y = (int *)0</string>

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -5130,23 +5130,6 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportOfFriendTemplateWithArgExpr) {
   EXPECT_NE(ToD1->getCanonicalDecl(), ToD2->getCanonicalDecl());
 }
 
-TEST_P(ASTImporterOptionSpecificTestBase, DISABLED_SourceLocationDifferentTU) {
-  TranslationUnitDecl *ToTU = getToTuDecl("void f1();", Lang_CXX11);
-  Decl *FromTU = getTuDecl("void f2();", Lang_CXX11, "input.cc");
-  auto *ToF1 = FirstDeclMatcher<FunctionDecl>().match(ToTU, functionDecl());
-  auto *FromF2 = FirstDeclMatcher<FunctionDecl>().match(FromTU, functionDecl());
-
-  auto *ToF2 = Import(FromF2, Lang_CXX11);
-
-  bool Before1 =
-      ToTU->getASTContext().getSourceManager().isBeforeInTranslationUnit(
-          ToF1->getLocation(), ToF2->getLocation());
-  bool Before2 =
-      ToTU->getASTContext().getSourceManager().isBeforeInTranslationUnit(
-          ToF2->getLocation(), ToF1->getLocation());
-  EXPECT_NE(Before1, Before2);
-}
-
 INSTANTIATE_TEST_CASE_P(ParameterizedTests, ASTImporterLookupTableTest,
                         DefaultTestValuesForRunOptions, );
 

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -5130,6 +5130,23 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportOfFriendTemplateWithArgExpr) {
   EXPECT_NE(ToD1->getCanonicalDecl(), ToD2->getCanonicalDecl());
 }
 
+TEST_P(ASTImporterOptionSpecificTestBase, DISABLED_SourceLocationDifferentTU) {
+  TranslationUnitDecl *ToTU = getToTuDecl("void f1();", Lang_CXX11);
+  Decl *FromTU = getTuDecl("void f2();", Lang_CXX11, "input.cc");
+  auto *ToF1 = FirstDeclMatcher<FunctionDecl>().match(ToTU, functionDecl());
+  auto *FromF2 = FirstDeclMatcher<FunctionDecl>().match(FromTU, functionDecl());
+
+  auto *ToF2 = Import(FromF2, Lang_CXX11);
+
+  bool Before1 =
+      ToTU->getASTContext().getSourceManager().isBeforeInTranslationUnit(
+          ToF1->getLocation(), ToF2->getLocation());
+  bool Before2 =
+      ToTU->getASTContext().getSourceManager().isBeforeInTranslationUnit(
+          ToF2->getLocation(), ToF1->getLocation());
+  EXPECT_NE(Before1, Before2);
+}
+
 INSTANTIATE_TEST_CASE_P(ParameterizedTests, ASTImporterLookupTableTest,
                         DefaultTestValuesForRunOptions, );
 


### PR DESCRIPTION
If a macro is to be expanded during diagnostic report creation the preprocessor for the original source file (where the macro was imported from) is used instead of the preprocessor for the actual source file (that do not contain correct macro informations). (If the macro is in imported code.)