### PR TITLE
NoStoreFuncVisitor fix for function without source range

### DIFF
--- a/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -324,7 +324,8 @@ public:
     CallEventRef<> Call =
         BR.getStateManager().getCallEventManager().getCaller(SCtx, State);
 
-    if (SM.isInSystemHeader(Call->getDecl()->getSourceRange().getBegin()))
+    SourceLocation BeginLoc = Call->getDecl()->getSourceRange().getBegin();
+    if (BeginLoc.isValid() && SM.isInSystemHeader(BeginLoc))
       return nullptr;
 
     // Region of interest corresponds to an IVar, exiting a method


### PR DESCRIPTION
The called decl may be a function that has no source range (the function is called without existing definition or declaration, this is possible in C89).