### PR TITLE
HandleNameConflict should receive the SearchName as parameter

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2553,7 +2553,8 @@ ExpectedDecl ASTNodeImporter::VisitEnumDecl(EnumDecl *D) {
 
     if (!ConflictingDecls.empty()) {
       Expected<DeclarationName> Resolution = Importer.HandleNameConflict(
-          Name, DC, IDNS, ConflictingDecls.data(), ConflictingDecls.size());
+          SearchName, DC, IDNS, ConflictingDecls.data(),
+          ConflictingDecls.size());
       if (Resolution)
         Name = Resolution.get();
       else
@@ -2690,7 +2691,8 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
 
     if (!ConflictingDecls.empty() && SearchName) {
       Expected<DeclarationName> Resolution = Importer.HandleNameConflict(
-          Name, DC, IDNS, ConflictingDecls.data(), ConflictingDecls.size());
+          SearchName, DC, IDNS, ConflictingDecls.data(),
+          ConflictingDecls.size());
       if (Resolution)
         Name = Resolution.get();
       else


### PR DESCRIPTION
This is actually the port back of
D62352 Call to HandleNameConflict in VisitRecordDecl mistakeningly using
Name instead of SearchName
and
D59665 Call to HandleNameConflict in VisitEnumDecl mistakeningly using
Name instead of SearchName

Related: #681 