### PR TITLE
Add test for a NoStoreFuncVisitor bug.

### DIFF
--- a/test/Analysis/ctu-main.c
+++ b/test/Analysis/ctu-main.c
@@ -45,11 +45,18 @@ void testMacro(void) {
   g(0); // expected-warning@Inputs/ctu-other.c:29 {{Access to field 'a' results in a dereference of a null pointer (loaded from variable 'ctx')}}
 }
 
+void h(int);
+
 // The external function prototype is incomplete.
 // warning:implicit functions are prohibited by c99
 void testImplicit() {
-  int res = identImplicit(6);   // external implicit functions are not inlined
+  int res = identImplicit(6);
   clang_analyzer_eval(res == 6); // expected-warning{{TRUE}}
+
+  // Call something with uninitialized from the same function in which the implicit was called.
+  // This is necessary to reproduce a special bug in NoStoreFuncVisitor.
+  int uninitialized;
+  h(uninitialized); // expected-warning@ctu-main.c:59 {{1st function call argument is an uninitialized value}}
 }
 
 // Tests the import of functions that have a struct parameter


### PR DESCRIPTION
This test can be used to reproduce this assertion:
```
clang: llvm/tools/clang/lib/Basic/SourceManager.cpp:1371: clang::SrcMgr::CharacteristicKind clang::SourceManager::getFileCharacteristic(clang::SourceLocation) const: Assertion `Loc.isValid() && "Can't get file characteristic of invalid loc!"' failed.
Stack dump:
0.      Program arguments: build/Debug/bin/clang -cc1 -internal-isystem build/Debug/lib/clang/8.0.1/include -nostdsysteminc -triple x86_64-pc-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=build/Debug/tools/clang/test/Analysis/Output/ctu-main.c.tmp/ctudir2 -verify llvm/tools/clang/test/Analysis/ctu-main.c 
1.      <eof> parser at end of file
 #0 0x00007f1f66fbb78f llvm::sys::PrintStackTrace(llvm::raw_ostream&) llvm/lib/Support/Unix/Signals.inc:495:0
 #1 0x00007f1f66fbb822 PrintStackTraceSignalHandler(void*) llvm/lib/Support/Unix/Signals.inc:559:0
 #2 0x00007f1f66fb93dc llvm::sys::RunSignalHandlers() llvm/lib/Support/Signals.cpp:69:0
 #3 0x00007f1f66fbb18a SignalHandler(int) llvm/lib/Support/Unix/Signals.inc:358:0
 #4 0x00007f1f627734b0 (/lib/x86_64-linux-gnu/libc.so.6+0x354b0)
 #5 0x00007f1f62773428 gsignal /build/glibc-LK5gWL/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
 #6 0x00007f1f6277502a abort /build/glibc-LK5gWL/glibc-2.23/stdlib/abort.c:91:0
 #7 0x00007f1f6276bbd7 __assert_fail_base /build/glibc-LK5gWL/glibc-2.23/assert/assert.c:92:0
 #8 0x00007f1f6276bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
 #9 0x00007f1f65a60be6 clang::SourceManager::getFileCharacteristic(clang::SourceLocation) const llvm/tools/clang/lib/Basic/SourceManager.cpp:1372:0
#10 0x00007f1f56ebf8d0 clang::SourceManager::isInSystemHeader(clang::SourceLocation) const llvm/tools/clang/include/clang/Basic/SourceManager.h:1446:0
#11 0x00007f1f56ead51a (anonymous namespace)::NoStoreFuncVisitor::VisitNode(clang::ento::ExplodedNode const*, clang::ento::BugReporterContext&, clang::ento::BugReport&) llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp:328:0
#12 0x00007f1f56e6d517 generateVisitorsDiagnostics(clang::ento::BugReport*, clang::ento::ExplodedNode const*, clang::ento::BugReporterContext&) llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporter.cpp:2576:0
#13 0x00007f1f56e6d8b3 findValidReport((anonymous namespace)::TrimmedGraph&, (anonymous namespace)::ReportGraph&, llvm::ArrayRef<clang::ento::BugReport*>&, clang::AnalyzerOptions&, clang::ento::GRBugReporter&) llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporter.cpp:2624:0
#14 0x00007f1f56e6dd18 clang::ento::GRBugReporter::generatePathDiagnostics(llvm::ArrayRef<clang::ento::PathDiagnosticConsumer*>, llvm::ArrayRef<clang::ento::BugReport*>&) llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporter.cpp:2673:0
#15 0x00007f1f56e6fd1d clang::ento::BugReporter::generateDiagnosticForConsumerMap(clang::ento::BugReport*, llvm::ArrayRef<clang::ento::PathDiagnosticConsumer*>, llvm::ArrayRef<clang::ento::BugReport*>) llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporter.cpp:3095:0
#16 0x00007f1f56e6eebd clang::ento::BugReporter::FlushReport(clang::ento::BugReportEquivClass&) llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporter.cpp:2949:0
#17 0x00007f1f56e6c08a clang::ento::BugReporter::FlushReports() llvm/tools/clang/lib/StaticAnalyzer/Core/BugReporter.cpp:2253:0
#18 0x00007f1f58572140 (anonymous namespace)::AnalysisConsumer::RunPathSensitiveChecks(clang::Decl*, clang::ento::ExprEngine::InliningModes, llvm::DenseSet<clang::Decl const*, llvm::DenseMapInfo<clang::Decl const*> >*) llvm/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp:738:0
#19 0x00007f1f58571e0b (anonymous namespace)::AnalysisConsumer::HandleCode(clang::Decl*, unsigned int, clang::ento::ExprEngine::InliningModes, llvm::DenseSet<clang::Decl const*, llvm::DenseMapInfo<clang::Decl const*> >*) llvm/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp:717:0
#20 0x00007f1f58570ac6 (anonymous namespace)::AnalysisConsumer::HandleDeclsCallGraph(unsigned int) llvm/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp:511:0
#21 0x00007f1f58570f32 (anonymous namespace)::AnalysisConsumer::runAnalysisOnTranslationUnit(clang::ASTContext&) llvm/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp:557:0
#22 0x00007f1f58571182 (anonymous namespace)::AnalysisConsumer::HandleTranslationUnit(clang::ASTContext&) llvm/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp:588:0
#23 0x00007f1f5b72da17 clang::ParseAST(clang::Sema&, bool, bool) llvm/tools/clang/lib/Parse/ParseAST.cpp:177:0
#24 0x00007f1f63cda721 clang::ASTFrontendAction::ExecuteAction() llvm/tools/clang/lib/Frontend/FrontendAction.cpp:1037:0
#25 0x00007f1f63cda100 clang::FrontendAction::Execute() llvm/tools/clang/lib/Frontend/FrontendAction.cpp:939:0
#26 0x00007f1f63c4a662 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) llvm/tools/clang/lib/Frontend/CompilerInstance.cpp:956:0
#27 0x00007f1f6370b005 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) llvm/tools/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp:268:0
#28 0x0000000000455748 cc1_main(llvm::ArrayRef<char const*>, char const*, void*) llvm/tools/clang/tools/driver/cc1_main.cpp:219:0
#29 0x000000000044aa4c ExecuteCC1Tool(llvm::ArrayRef<char const*>, llvm::StringRef) llvm/tools/clang/tools/driver/driver.cpp:310:0
#30 0x000000000044b791 main llvm/tools/clang/tools/driver/driver.cpp:382:0
#31 0x00007f1f6275e830 __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:325:0
#32 0x0000000000448369 _start (build/Debug/bin/clang+0x448369)
build/Debug/tools/clang/test/Analysis/Output/ctu-main.c.script: line 5: 26356 Aborted                 (core dumped) build/Debug/bin/clang -cc1 -internal-isystem build/Debug/lib/clang/8.0.1/include -nostdsysteminc -triple x86_64-pc-linux-gnu -fsyntax-only -std=c89 -analyze -analyzer-checker=core,debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=build/Debug/tools/clang/test/Analysis/Output/ctu-main.c.tmp/ctudir2 -verify llvm/tools/clang/test/Analysis/ctu-main.c
```

The problem is fixed in #684 already.