### PR TITLE
[Analyzer] Iterator Checkers - Crash Fix

### DIFF
--- a/lib/StaticAnalyzer/Checkers/IteratorChecker.cpp
+++ b/lib/StaticAnalyzer/Checkers/IteratorChecker.cpp
@@ -2121,6 +2121,9 @@ ProgramStateRef relateIteratorPositions(ProgramStateRef State,
     "Symbol comparison must be a `DefinedSVal`");
 
   auto NewState = State->assume(comparison.castAs<DefinedSVal>(), Equal);
+  if (!NewState)
+    return nullptr;
+
   if (const auto CompSym = comparison.getAsSymbol()) {
     assert(isa<SymIntExpr>(CompSym) &&
            "Symbol comparison must be a `SymIntExpr`");


### PR DESCRIPTION
When relating iterator positions the relation may be impossible because
of the constraints. In this case the new state we get is a null pointer.
If so, return a null pointer immediately instead of working with the
invalid (null pointer) state wihch crashes the analyzer.